### PR TITLE
Move complaint tests from singleItemTender into singleItemTenderComplaints; improve PEP8 compliance

### DIFF
--- a/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
+++ b/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
@@ -1,10 +1,11 @@
 from openprocurement_client.client import Client
 import sys
 
-def prepare_api_wrapper(key='', host_url="https://api-sandbox.openprocurement.org", api_version='0.8' ):
-    return Client(key, host_url, api_version )
+
+def prepare_api_wrapper(key='', host_url="https://api-sandbox.openprocurement.org", api_version='0.8'):
+    return Client(key, host_url, api_version)
+
 
 def get_internal_id(get_tenders_function, date):
-	result = get_tenders_function({"offset": date, "opt_fields": 'tenderID', })
-	#import pdb; pdb.Pdb(stdout=sys.__stdout__).set_trace()
-	return result
+    result = get_tenders_function({"offset": date, "opt_fields": 'tenderID'})
+    return result

--- a/op_robot_tests/tests_files/etender_service.py
+++ b/op_robot_tests/tests_files/etender_service.py
@@ -1,26 +1,28 @@
+from datetime import date, datetime, timedelta
+from dateutil.parser import parse
+from dateutil.tz import tzlocal
 from iso8601 import parse_date
+from jsonpath_rw import parse as parse_path
+from pytz import timezone
 from robot.output import LOGGER
 from robot.output.loggerhelper import Message
 from robot.libraries.BuiltIn import BuiltIn
 from robot.errors import HandlerExecutionFailed
-from datetime import datetime, timedelta, date
-from dateutil.parser import parse
-from dateutil.tz import tzlocal
-from pytz import timezone
-from jsonpath_rw import parse as parse_path
-import time
 from op_robot_tests.tests_files.initial_data import (
     test_tender_data
 )
+import time
 
 TIMEZONE = timezone('Europe/Kiev')
 
+
 def convert_date_to_etender_format(isodate):
-    iso_dt=parse_date(isodate)
+    iso_dt = parse_date(isodate)
     date_string = iso_dt.strftime("%d-%m-%Y")
-    return  date_string
+    return date_string
+
 
 def convert_time_to_etender_format(isodate):
-    iso_dt=parse_date(isodate)
+    iso_dt = parse_date(isodate)
     time_string = iso_dt.strftime("%H:%M")
-    return  time_string
+    return time_string

--- a/op_robot_tests/tests_files/singleItemTender.robot
+++ b/op_robot_tests/tests_files/singleItemTender.robot
@@ -37,21 +37,6 @@ ${question_id}  0
   Set To Dictionary  ${USERS.users['${tender_owner}']}   file_upload_process_data   ${file_upload_process_data}
   Log  ${USERS.users['${tender_owner}']}
 
-Можливість подати скаргу на умови
-  [Tags]   ${USERS.users['${provider}'].broker}: Можливість подати скаргу на умови
-  [Documentation]    Користувач  ${USERS.users['${provider}'].broker}  намагається подати скаргу на умови оголошеної  закупівлі
-  Викликати для учасника   ${provider}   Подати скаргу    ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
-  ${LAST_MODIFICATION_DATE}=  Get Current Date
-  Set To Dictionary  ${TENDER}   LAST_MODIFICATION_DATE  ${LAST_MODIFICATION_DATE}
-
-Можливість побачити скаргу користувачем
-  [Tags]   ${USERS.users['${provider}'].broker}: Відображення основних даних оголошеного тендера
-  Викликати для учасника   ${provider}   Порівняти скаргу  ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
-
-Можливість побачити скаргу анонімом
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних оголошеного тендера
-  Викликати для учасника    ${viewer}  Порівняти скаргу  ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
-
 Пошук однопредметного тендера по ідентифікатору
   [Tags]   ${USERS.users['${viewer}'].broker}: Пошук тендера по ідентифікатору
   Дочекатись синхронізації з майданчиком    ${viewer}
@@ -231,14 +216,6 @@ ${question_id}  0
   Викликати для учасника   ${viewer}   Оновити сторінку з тендером   ${TENDER['TENDER_UAID']}
   Звірити поле  ${viewer}   questions[${question_id}].answer    ${ANSWERS[${question_id}].data.answer}
 
-Можливість побачити скаргу користувачем під час періоду уточнень
-  [Tags]   ${USERS.users['${provider}'].broker}: Відображення основних даних оголошеного тендера
-  Викликати для учасника   ${provider}   Порівняти скаргу  ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
-
-Можливість побачити скаргу анонімом під час періоду уточнень
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних оголошеного тендера
-  Викликати для учасника    ${viewer}  Порівняти скаргу  ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
-
 Подати цінову пропозицію bidder
   [Tags]   ${USERS.users['${provider}'].broker}: Можливість подати цінову пропозицію
   Дочекатись дати початку прийому пропозицій
@@ -337,14 +314,6 @@ ${question_id}  0
   ${filepath}=   create_fake_doc
   ${bid_doc_upload}=  Викликати для учасника   ${provider1}   Завантажити документ в ставку  ${filepath}   ${TENDER['TENDER_UAID']}
   Set To Dictionary  ${USERS.users['${provider1}'].bidresponses}   bid_doc_upload   ${bid_doc_upload}
-
-Можливість побачити скаргу користувачем під час подачі пропозицій
-  [Tags]   ${USERS.users['${provider}'].broker}: Відображення основних даних оголошеного тендера
-  Викликати для учасника   ${provider}   Порівняти скаргу  ${TENDER['TENDER_UAID']}    ${COMPLAINTS[0]}
-
-Можливість побачити скаргу анонімом під час подачі пропозицій
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних оголошеного тендера
-  Викликати для учасника    ${viewer}  Порівняти скаргу  ${TENDER['TENDER_UAID']}    ${COMPLAINTS[0]}
 
 Неможливість змінити цінову пропозицію до 50000 після закінчення прийому пропозицій
   [Tags]   ${USERS.users['${provider1}'].broker}: Неможливість змінити цінову пропозицію до 50000 після закінчення прийому пропозицій

--- a/op_robot_tests/tests_files/singleItemTenderComplaints.robot
+++ b/op_robot_tests/tests_files/singleItemTenderComplaints.robot
@@ -32,9 +32,18 @@ ${broker}       Quinta
 
 Можливість подати скаргу на умови
   [Tags]   ${USERS.users['${provider}'].broker}: Можливість подати скаргу на умови
+  [Documentation]    Користувач  ${USERS.users['${provider}'].broker}  намагається подати скаргу на умови оголошеної  закупівлі
   Викликати для учасника   ${provider}   Подати скаргу    ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
   ${LAST_MODIFICATION_DATE}=  Get Current Date
   Set Global Variable   ${LAST_MODIFICATION_DATE}
+
+Можливість побачити скаргу користувачем
+  [Tags]   ${USERS.users['${provider}'].broker}: Відображення основних даних оголошеного тендера
+  Викликати для учасника   ${provider}   Порівняти скаргу  ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
+
+Можливість побачити скаргу анонімом
+  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних оголошеного тендера
+  Викликати для учасника    ${viewer}  Порівняти скаргу  ${TENDER['TENDER_UAID']}   ${COMPLAINTS[0]}
 
 Можливість відхилити скаргу на умови
   [Tags]   ${USERS.users['${tender_owner}'].broker}: Можливість відхилити скаргу на умови

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
-import sys, os
+import os
+import sys
 
 version = '0.0'
 
@@ -8,7 +9,7 @@ setup(name='op_robot_tests',
       description="",
       long_description="""\
 """,
-      classifiers=[], # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
+      classifiers=[],  # Get strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       keywords='',
       author='',
       author_email='',


### PR DESCRIPTION
Two test cases were moved into singleItemTenderComplaints and one was already there.
Four more were dropped since they are same as first two.