### PR TITLE
Stop fetching dependencies from Git; fix #22

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -31,7 +31,7 @@ interpreter = python_interpreter
 initialization =
     from munch import Munch
     Munch.__str__ = lambda self: Munch.toYAML(self, allow_unicode=True,
-                                              default_flow_style=False)
+                                              default_flow_style=False).decode('utf-8')
     Munch.__repr__ = Munch.__str__
 
 [remotes]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,6 +2,8 @@
 extensions = mr.developer
 auto-checkout = *
 develop = .
+find-links =
+    http://op:x9W3jZ@dist.quintagroup.com/op/
 
 parts =
     mkdirs
@@ -39,11 +41,11 @@ gh = git://github.com/
 gh_push = git@github.com:
 
 [sources]
-robotframework-selenium2library = git ${remotes:gh}ktarasz/robotframework-selenium2library.git
-fake-factory                    = git ${remotes:gh}joke2k/faker.git
 openprocurement_client          = git ${remotes:gh}openprocurement/openprocurement.client.python.git
-restkit                         = git ${remotes:gh}openprocurement/restkit.git
-rfc6266                         = git ${remotes:gh}openprocurement/rfc6266.git  branch=content-disposition-form-data
 
 [versions]
+fake-factory = 0.5.3
+restkit = 4.2.2.op1
+rfc6266 = 0.0.6.op1
 robotframework = 2.8.7
+robotframework-selenium2library = 1.7.4


### PR DESCRIPTION
The first commit saves a lot of time, disk space and network traffic by fetching dependencies as eggs and source distributions instead of cloning their Git repositories. Changes in openprocurement_client happen quite frequently, so it remained intact.

The second commit contains a small fix for #22.