### PR TITLE
Add qualification and contract tests

### DIFF
--- a/op_robot_tests/tests_files/brokers/openprocurement_client.robot
+++ b/op_robot_tests/tests_files/brokers/openprocurement_client.robot
@@ -336,6 +336,59 @@ Library  openprocurement_client_helper.py
   #${tender}=  openprocurement_client.Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
 
 ##############################################################################
+#             Qualification Operations
+##############################################################################
+
+Завантажити документ рішення кваліфікаційної комісії
+  [Documentation]
+  ...      [Arguments] Username, tender uaid, qualification number and document to upload
+  ...      [Description] Find tender using uaid,  and call upload_qualification_document
+  ...      [Return] Reply of API
+  [Arguments]  ${username}  ${document}  ${tender_uaid}  ${award_num}
+  ${tender}=  Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
+  ${doc_reply}=  Call Method  ${USERS.users['${username}'].client}  upload_award_document  ${document}  ${tender}  ${tender.data.awards[${award_num}].id}
+  Log  ${doc_reply}
+  [Return]  ${doc_reply}
+
+Підтвердити постачальника
+  [Documentation]
+  ...      [Arguments] Username, tender uaid and number of the award to confirm
+  ...      Find tender using uaid, get data from confirm_supplier and call patch_award
+  ...      [Return] Nothing
+  [Arguments]  ${username}  ${tender_uaid}  ${award_num}
+  ${tender}=  Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
+  ${award}=  create_data_dict  data.status  active
+  Set To Dictionary  ${award.data}  id  ${tender.data.awards[${award_num}].id}
+  ${reply}=  Call Method  ${USERS.users['${username}'].client}  patch_award  ${tender}  ${award}
+  Log  ${reply}
+
+Дискваліфікація постачальника
+  [Documentation]
+  ...      [Arguments] Username, tender uaid and award number
+  ...      [Description] Find tender using uaid, create data dict with unsuccessful status and call patch_award
+  ...      [Return] Reply of API
+  [Arguments]  ${username}  ${tender_uid}  ${award_num}
+  ${tender}=  openprocurement_client.Пошук тендера по ідентифікатору  ${username}  ${tender_uid}
+  ${award}=  create_data_dict   data.status  unsuccessful
+  Set To Dictionary  ${award.data}  id  ${tender.data.awards[${award_num}].id}
+  ${reply}=  Call Method  ${USERS.users['${username}'].client}  patch_award  ${tender}  ${award}
+  Log  ${reply}
+  [Return]  ${reply}
+
+Скасування рішення кваліфікаційної комісії
+  [Documentation]
+  ...      [Arguments] Username, tender uaid and award number
+  ...      [Description] Find tender using uaid, create data dict with unsuccessful status and call patch_award
+  ...      [Return] Reply of API
+  [Arguments]  ${username}  ${tender_uid}  ${award_num}
+  ${tender}=  openprocurement_client.Пошук тендера по ідентифікатору  ${username}  ${tender_uid}
+  ${award}=  create_data_dict   data.status  cancelled
+  Set To Dictionary  ${award.data}  id  ${tender.data.awards[${award_num}].id}
+  ${reply}=  Call Method  ${USERS.users['${username}'].client}  patch_award  ${tender}  ${award}
+  Log  ${reply}
+  [Return]  ${reply}
+
+##############################################################################
 #             Limited procurement
 ##############################################################################
 
@@ -364,20 +417,6 @@ Library  openprocurement_client_helper.py
   Log  ${reply}
   ${supplier_number}=  Set variable  0
   Підтвердити постачальника  ${username}  ${tender_uaid}  ${supplier_number}
-
-
-Підтвердити постачальника
-  [Documentation]
-  ...      [Arguments] Username, tender uaid and number of the award to confirm
-  ...      Find tender using uaid, get data from confirm_supplier and call patch_award
-  ...      [Return] Nothing
-  [Arguments]  ${username}  ${tender_uaid}  ${award_num}
-  ${tender}=  Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
-  ${data}=  test_confirm_data  ${tender['data']['awards'][${award_num}]['id']}
-  Log  ${data}
-  ${reply}=  Call Method  ${USERS.users['${username}'].client}  patch_award  ${tender}  ${data}
-  Log  ${reply}
-
 
 Скасувати закупівлю
   [Documentation]

--- a/op_robot_tests/tests_files/contract.robot
+++ b/op_robot_tests/tests_files/contract.robot
@@ -1,0 +1,39 @@
+*** Settings ***
+Resource        keywords.robot
+Resource        resource.robot
+Suite Setup     Test Suite Setup
+Suite Teardown  Test Suite Teardown
+
+*** Variables ***
+${role}         viewer
+${broker}       Quinta
+
+
+*** Test Cases ***
+Пошук позапорогового однопредметного тендера по ідентифікатору
+  [Tags]   ${USERS.users['${viewer}'].broker}: Пошук тендера по ідентифікатору
+  ...      viewer  tender_owner
+  ...      ${USERS.users['${viewer}'].broker}  ${USERS.users['${tender_owner}'].broker}
+  ...      minimal
+  Завантажити дані про тендер
+  ${usernames}=  Create List  ${viewer}  ${tender_owner}
+  :FOR  ${username}  IN  @{usernames}
+  \   ${resp}=  Викликати для учасника  ${username}  Пошук тендера по ідентифікатору   ${TENDER['TENDER_UAID']}
+  Log  ${resp}
+
+##############################################################################################
+#             CONTRACT
+##############################################################################################
+
+Можливість укласти угоду для прямої закупівлі
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Можливість укласти угоду для прямої закупівлі
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  Викликати для учасника  ${tender_owner}  Підтвердити підписання контракту  ${TENDER['TENDER_UAID']}  1
+
+
+Відображення статусу підписаної угоди з постачальником прямої закупівлі
+  [Tags]  ${USERS.users['${viewer}'].broker}: Відображення статусу підписаної угоди з постачальником прямої закупівлі
+  ...  viewer
+  ...  ${USERS.users['${viewer}'].broker}
+  Звірити поле тендера із значенням  ${viewer}  active  contracts[1].status

--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -18,8 +18,13 @@ Test Suite Setup
 
 Test Suite Teardown
   Close all browsers
-  ${artifact}=  Create Dictionary  tender_uaid=${TENDER['TENDER_UAID']}  access_token=${USERS.users['${tender_owner}'].access_token}
-  log_object_data  ${artifact}  arctifact
+  ${artifact}=  Create Dictionary
+  ...      api_version=${api_version}
+  ...      tender_uaid=${TENDER['TENDER_UAID']}
+  ...      tender_owner=${USERS.users['${tender_owner}'].broker}
+  Run Keyword If  '${USERS.users['${tender_owner}'].broker}' == 'Quinta'
+  ...      Set To Dictionary  ${artifact}   access_token=${USERS.users['${tender_owner}'].access_token}
+  log_object_data  ${artifact}  artifact
 
 
 Set Suite Variable With Default Value
@@ -82,6 +87,14 @@ Get Broker Property By Username
   [Arguments]  ${username}  ${property}
   ${broker_name}=  Get Variable Value  ${USERS.users['${username}'].broker}
   Run Keyword And Return  Get Broker Property  ${broker_name}  ${property}
+
+Завантажити дані про тендер
+  ${file_path}=  Get Variable Value  ${ARTIFACT_FILE}  artifact.yaml
+  ${ARTIFACT}=  load_initial_data_from  ${file_path}
+  Set To Dictionary  ${USERS.users['${tender_owner}']}  access_token  ${ARTIFACT.access_token}
+  ${TENDER}=  Create Dictionary
+  Set To Dictionary  ${TENDER}   TENDER_UAID             ${ARTIFACT.tender_uaid}
+  Set Global Variable  ${TENDER}
 
 
 Підготовка даних для створення тендера

--- a/op_robot_tests/tests_files/qualification.robot
+++ b/op_robot_tests/tests_files/qualification.robot
@@ -1,0 +1,106 @@
+*** Settings ***
+Resource        keywords.robot
+Resource        resource.robot
+Suite Setup     Test Suite Setup
+Suite Teardown  Test Suite Teardown
+
+*** Variables ***
+${role}         viewer
+${broker}       Quinta
+
+
+*** Test Cases ***
+Пошук позапорогового однопредметного тендера по ідентифікатору
+  [Tags]   ${USERS.users['${viewer}'].broker}: Пошук тендера по ідентифікатору
+  ...      viewer  tender_owner
+  ...      ${USERS.users['${viewer}'].broker}  ${USERS.users['${tender_owner}'].broker}
+  ...      minimal
+  Завантажити дані про тендер
+  ${usernames}=  Create List  ${viewer}  ${tender_owner}
+  :FOR  ${username}  IN  @{usernames}
+  \   ${resp}=  Викликати для учасника  ${username}  Пошук тендера по ідентифікатору   ${TENDER['TENDER_UAID']}
+  Log  ${resp}
+
+##############################################################################################
+#             AWARDS
+##############################################################################################
+
+Відображення статусу кваліфікації
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Відображення основних даних оголошеного тендера
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ${usernames}=  Create List  ${viewer}  ${tender_owner}
+  :FOR  ${username}  IN  @{usernames}
+  \   Звірити поле тендера із значенням  ${tender_owner}  active.qualification  status
+
+Відображення вартості номенклатури постачальника
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Відображення основних даних оголошеного тендера
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ${usernames}=  Create List  ${viewer}  ${tender_owner}
+  :FOR  ${username}  IN  @{usernames}
+  \  Викликати для учасника  ${username}  Отримати інформацію із тендера  awards[0].value.amount
+
+Відображення імені постачальника
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Відображення основних даних оголошеного тендера
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ${usernames}=  Create List  ${viewer}  ${tender_owner}
+  :FOR  ${username}  IN  @{usernames}
+  \  Викликати для учасника  ${username}  Отримати інформацію із тендера  awards[0].suppliers[0].name
+
+Відображення офіційного імені постачальника
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Відображення основних даних оголошеного тендера
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ${usernames}=  Create List  ${viewer}  ${tender_owner}
+  :FOR  ${username}  IN  @{usernames}
+  \  Викликати для учасника  ${username}  Отримати інформацію із тендера  awards[0].suppliers[0].identifier.legalName
+
+Відображення ідентифікатора постачальника
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Відображення основних даних оголошеного тендера
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ${usernames}=  Create List  ${viewer}  ${tender_owner}
+  :FOR  ${username}  IN  @{usernames}
+  \  Викликати для учасника  ${username}  Отримати інформацію із тендера  awards[0].suppliers[0].identifier.id
+
+
+##############################################################################################
+#             QUALIFICATION
+##############################################################################################
+
+Можливість завантажити документ рішення кваліфікаційної комісії для підтвердження постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Можливість укласти угоду для прямої закупівлі
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ${filepath}=   create_fake_doc
+  Викликати для учасника   ${tender_owner}   Завантажити документ рішення кваліфікаційної комісії   ${filepath}   ${TENDER['TENDER_UAID']}   0
+
+Можливість підтвердити постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Можливість зареєструвати і підтвердити постачальника до прямої закупівлі
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  minimal
+  Викликати для учасника  ${tender_owner}  Підтвердити постачальника  ${TENDER['TENDER_UAID']}  0
+
+Можливість скасувати рішення кваліфікації
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Можливість зареєструвати і підтвердити постачальника до прямої закупівлі
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  minimal
+  Викликати для учасника  ${tender_owner}  Скасування рішення кваліфікаційної комісії  ${TENDER['TENDER_UAID']}  0
+
+Можливість завантажити документ рішення кваліфікаційної комісії для підтвердження нового постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Можливість укласти угоду для прямої закупівлі
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ${filepath}=   create_fake_doc
+  Викликати для учасника   ${tender_owner}   Завантажити документ рішення кваліфікаційної комісії   ${filepath}   ${TENDER['TENDER_UAID']}   1
+
+Можливість підтвердити нового постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Можливість зареєструвати і підтвердити постачальника до прямої закупівлі
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  minimal
+  Викликати для учасника  ${tender_owner}  Підтвердити постачальника  ${TENDER['TENDER_UAID']}  1


### PR DESCRIPTION
Для запуску потребує `arctifact.yaml` у op_robot_tests/tests_files/datа.

`tender test -> (auction) ->  qualification test -> contract test`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/73)
<!-- Reviewable:end -->
