### PR TITLE
Add convertation to string in `Порівняти об'єкти`

### DIFF
--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -322,6 +322,8 @@ Get Broker Property By Username
   Log  ${right}
   Should Not Be Equal  ${left}  ${None}
   Should Not Be Equal  ${right}  ${None}
+  ${left}=  Convert To String  ${left}
+  ${right}=  Convert To String  ${right}
   Should Be Equal  ${left}  ${right}  msg=Objects are not equal
 
 


### PR DESCRIPTION
Keyword failed when arguments had the same value but different types.
Не перевіряв, чи це нічого не ламає.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/135)
<!-- Reviewable:end -->