### PR TITLE
Fix caching initial tender data

### DIFF
--- a/op_robot_tests/tests_files/meatTender.robot
+++ b/op_robot_tests/tests_files/meatTender.robot
@@ -27,7 +27,7 @@ ${broker}       Quinta
   ${tender_data}=  test_meat_tender_data  ${base_tender_data}
   ${adapted_data}=  Адаптувати дані для оголошення тендера  ${tender_owner}  ${tender_data}
   ${TENDER_UAID}=  Викликати для учасника  ${tender_owner}  Створити тендер  ${adapted_data}
-  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data  ${tender_data}
+  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data=${adapted_data}
   Set To Dictionary  ${TENDER}   TENDER_UAID             ${TENDER_UAID}
   Log  ${TENDER}
 

--- a/op_robot_tests/tests_files/multiItemTender.robot
+++ b/op_robot_tests/tests_files/multiItemTender.robot
@@ -25,7 +25,7 @@ ${broker}       Quinta
   ${tender_data}=  Підготовка даних для створення тендера
   ${adapted_data}=  Адаптувати дані для оголошення тендера  ${tender_owner}  ${tender_data}
   ${TENDER_UAID}=  Викликати для учасника  ${tender_owner}  Створити тендер  ${adapted_data}
-  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data  ${tender_data}
+  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data=${adapted_data}
   Set To Dictionary  ${TENDER}   TENDER_UAID             ${TENDER_UAID}
   log  ${TENDER}
 

--- a/op_robot_tests/tests_files/multiLotTender.robot
+++ b/op_robot_tests/tests_files/multiLotTender.robot
@@ -28,7 +28,7 @@ ${complaint_id}  1
   ${tender_data}=  test_tender_data_multiple_lots  ${tender_data}
   ${adapted_data}=  Адаптувати дані для оголошення тендера  ${tender_owner}  ${tender_data}
   ${TENDER_UAID}=  Викликати для учасника  ${tender_owner}  Створити тендер  ${adapted_data}
-  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data  ${tender_data}
+  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data=${adapted_data}
   Set To Dictionary  ${TENDER}   TENDER_UAID             ${TENDER_UAID}
   Log  ${TENDER}
 

--- a/op_robot_tests/tests_files/openEU.robot
+++ b/op_robot_tests/tests_files/openEU.robot
@@ -22,7 +22,7 @@ ${broker}       Quinta
   ${tender_data}=  Підготовка даних для створення тендера
   ${adapted_data}=  Адаптувати дані для оголошення тендера  ${tender_owner}  ${tender_data}
   ${TENDER_UAID}=  Викликати для учасника  ${tender_owner}  Створити тендер  ${adapted_data}
-  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data  ${tender_data}
+  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data=${adapted_data}
   Set To Dictionary  ${TENDER}   TENDER_UAID             ${TENDER_UAID}
   Log  ${TENDER}
 

--- a/op_robot_tests/tests_files/openUA.robot
+++ b/op_robot_tests/tests_files/openUA.robot
@@ -22,7 +22,7 @@ ${broker}       Quinta
   ${tender_data}=  Підготовка даних для створення тендера
   ${adapted_data}=  Адаптувати дані для оголошення тендера  ${tender_owner}  ${tender_data}
   ${TENDER_UAID}=  Викликати для учасника  ${tender_owner}  Створити тендер  ${adapted_data}
-  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data  ${tender_data}
+  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data=${adapted_data}
   Set To Dictionary  ${TENDER}   TENDER_UAID             ${TENDER_UAID}
   Log  ${TENDER}
 

--- a/op_robot_tests/tests_files/singleItemTender.robot
+++ b/op_robot_tests/tests_files/singleItemTender.robot
@@ -26,7 +26,7 @@ ${broker}       Quinta
   ${tender_data}=  Підготовка даних для створення тендера
   ${adapted_data}=  Адаптувати дані для оголошення тендера  ${tender_owner}  ${tender_data}
   ${TENDER_UAID}=  Викликати для учасника  ${tender_owner}  Створити тендер  ${adapted_data}
-  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data=${tender_data}
+  Set To Dictionary  ${USERS.users['${tender_owner}']}  initial_data=${adapted_data}
   Set To Dictionary  ${TENDER}  TENDER_UAID=${TENDER_UAID}
   Log  ${TENDER}
 


### PR DESCRIPTION
From initial_data=${tender_data} to initial_data=${adapted_data}
It was copy-paste error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/143)
<!-- Reviewable:end -->