### PR TITLE
Change max value of tender.value.amount

### DIFF
--- a/op_robot_tests/tests_files/initial_data.py
+++ b/op_robot_tests/tests_files/initial_data.py
@@ -48,7 +48,7 @@ def create_fake_doc():
 
 def test_tender_data(intervals, periods=("enquiry", "tender")):
     now = get_now()
-    value_amount = round(random.uniform(3000, 250000000000), 2)  # max value equals to budget of Ukraine in hryvnias
+    value_amount = round(random.uniform(3000, 99999999999.99), 2)  # max value equals to budget of Ukraine in hryvnias
     data = {
         "mode": "test",
         "submissionMethodDetails": "quick",


### PR DESCRIPTION
Because broker DZO can't display so many digits
This must be changed back in few months

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/185)
<!-- Reviewable:end -->
