### PR TITLE
Delete useless spaces from op_faker_data.json

### DIFF
--- a/op_robot_tests/tests_files/op_faker/op_faker_data.json
+++ b/op_robot_tests/tests_files/op_faker/op_faker_data.json
@@ -1465,7 +1465,7 @@
                 "longitude": 34.579872
             },
             "deliveryAddress": {
-                "postalCode": "51939 ",
+                "postalCode": "51939",
                 "countryName": "Україна",
                 "streetAddress": "Харківська вулиця, 49",
                 "region": "Дніпропетровська область",
@@ -7909,7 +7909,7 @@
         },
         {
             "cpv_id": "24910000-6",
-            "description": "Клей СМ-11 ",
+            "description": "Клей СМ-11",
             "quantity": 50,
             "unit": {
                 "code": "KGM",


### PR DESCRIPTION
Because checking display of this fields was failing for DZO and privatmarker

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/201)
<!-- Reviewable:end -->
