### PR TITLE
Delete `Викликати для учасника` from keywords.robot

### DIFF
--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -580,20 +580,6 @@ Get Broker Property By Username
   [Return]  ${field_value}
 
 
-Викликати для учасника
-  [Arguments]  ${username}  ${command}  @{arguments}
-  Run keyword unless  '${WARN_RUN_AS}' == '${True}'
-  ...      Run keywords
-  ...
-  ...      Set Suite Variable  ${WARN_RUN_AS}  ${True}
-  ...
-  ...      AND
-  ...
-  ...      Log  Keyword 'Викликати для учасника' is deprecated. Please use 'Run As' and 'Require Failure' instead.
-  ...      WARN
-  Run Keyword And Return  Run As  ${username}  ${command}  @{arguments}
-
-
 Run As
   [Arguments]  ${username}  ${command}  @{arguments}
   [Documentation]


### PR DESCRIPTION
Because it is replaced with `Run as` everywhere

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/219)
<!-- Reviewable:end -->
