### PR TITLE
Rename procurementMethodType for competitiveDialogue

### DIFF
--- a/op_robot_tests/tests_files/initial_data.py
+++ b/op_robot_tests/tests_files/initial_data.py
@@ -382,7 +382,7 @@ def test_tender_data_competitive_dialogue(params):
     # an openUA or openEU procedure. That field should not be present at all.
     # Therefore, we pass a nondefault list of periods to `test_tender_data()`.
     data = test_tender_data(params, ('tender',))
-    data['procurementMethodType'] = 'competitiveDialogue.aboveThreshold' + params.get('dialogue_type', 'EU')
+    data['procurementMethodType'] = 'competitiveDialogue' + params.get('dialogue_type', 'EU')
     data['title_en'] = "[TESTING] {}".format(fake_en.sentence(nb_words=3, variable_nb_words=True))
     for item in data['items']:
         item['description_en'] = fake_en.sentence(nb_words=3, variable_nb_words=True)

--- a/op_robot_tests/tests_files/service_keywords.py
+++ b/op_robot_tests/tests_files/service_keywords.py
@@ -450,7 +450,7 @@ def get_document_index_by_id(data, document_id):
 
 def generate_test_bid_data(tender_data):
     bid = test_bid_data()
-    if 'aboveThreshold' in tender_data.get('procurementMethodType', ''):
+    if 'aboveThreshold' in tender_data.get('procurementMethodType', '') or 'competitiveDialogue' in tender_data.get('procurementMethodType', ''):
         bid.data.selfEligible = True
         bid.data.selfQualified = True
     if 'lots' in tender_data:


### PR DESCRIPTION
Зміни пов'язані з перейменуванням типу процедури для  конкурентного діалогу

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/241)
<!-- Reviewable:end -->
