### PR TITLE
Rewrite `retry_if_request_failed`

### DIFF
--- a/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
+++ b/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
@@ -1,14 +1,21 @@
 from openprocurement_client.client import Client
 from openprocurement_client.utils import get_tender_id_by_uaid
 from openprocurement_client.exceptions import IdNotFound
-from restkit.errors import RequestFailed
+from restkit.errors import RequestFailed, BadStatusLine
 from retrying import retry
 import os
 import urllib
 
 
 def retry_if_request_failed(exception):
-    return isinstance(exception, RequestFailed)
+    if isinstance(exception, RequestFailed):
+        status_code = getattr(exception, 'status_int', None)
+        if 500 <= status_code < 600 or status_code == 429:
+            return True
+        else:
+            return False
+    else:
+        return isinstance(exception, BadStatusLine)
 
 
 class StableClient(Client):


### PR DESCRIPTION
Retry only requests with 5xx and 429 status codes or requests which throw BadStatusLine exception.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/282)
<!-- Reviewable:end -->
