### PR TITLE
Add checking for none value

### DIFF
--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -673,5 +673,9 @@ Require Failure
 Оновити LAST_MODIFICATION_DATE
   ${LAST_MODIFICATION_DATE}=  Get Current TZdate
   ${status}=  Get Variable Value  ${TEST_STATUS}
+  #None is added to update LMD not in teardown section.
+  #About empty - i don't know what it is doing here. Maybe there are some workarounds,
+  #so i left it as it was.
   Run Keyword If  '${status}' == 'PASS'  Set To Dictionary  ${TENDER}  LAST_MODIFICATION_DATE=${LAST_MODIFICATION_DATE}
   ...         ELSE IF  '${status}' == '${Empty}'  Set To Dictionary  ${TENDER}  LAST_MODIFICATION_DATE=${LAST_MODIFICATION_DATE}
+  ...         ELSE IF  '${status}' == '${None}'  Set To Dictionary  ${TENDER}  LAST_MODIFICATION_DATE=${LAST_MODIFICATION_DATE}


### PR DESCRIPTION
None is added to update LMD not in teardown section.
About empty - i dont know what it is doing here. Maybe there are some workarounds,
so i left it as it was.
Thx to @OSerhii for thix fix.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/292)
<!-- Reviewable:end -->
