### PR TITLE
Use artificial id instead of internal in work with bid documents

### DIFF
--- a/op_robot_tests/tests_files/aboveThreshold_keywords.robot
+++ b/op_robot_tests/tests_files/aboveThreshold_keywords.robot
@@ -42,8 +42,7 @@ Resource           base_keywords.robot
   ${confidentialityRationale}=  create_fake_sentence
   ${privat_doc}=  create_data_dict  data.confidentialityRationale  ${confidentialityRationale}
   Set To Dictionary  ${privat_doc.data}  confidentiality=buyerOnly
-  ${docid}=  Get Variable Value  ${USERS.users['${username}'].bidresponses['bid_doc_upload']['upload_response'].data.id}
-  Run As  ${username}  Змінити документацію в ставці  ${TENDER['TENDER_UAID']}  ${privat_doc}  ${docid}
+  Run As  ${username}  Змінити документацію в ставці  ${TENDER['TENDER_UAID']}  ${privat_doc}  ${USERS.users['${username}'['bid_document']['doc_id']}
 
 
 Можливість завантажити ${doc_type} документ до пропозиції учасником ${username}

--- a/op_robot_tests/tests_files/base_keywords.robot
+++ b/op_robot_tests/tests_files/base_keywords.robot
@@ -970,15 +970,25 @@ Resource           resource.robot
 
 Можливість завантажити документ в пропозицію користувачем ${username}
   ${file_path}  ${file_name}  ${file_content}=  create_fake_doc
-  ${bid_doc_upload}=  Run As  ${username}  Завантажити документ в ставку  ${file_path}  ${TENDER['TENDER_UAID']}
-  Set To Dictionary  ${USERS.users['${username}'].bidresponses}  bid_doc_upload=${bid_doc_upload}
+  ${doc_id}=  get_id_from_string  ${file_name}
+  ${bid_document_data}=  Create Dictionary
+  ...      doc_name=${file_name}
+  ...      doc_content=${file_content}
+  ...      doc_id=${doc_id}
+  Run As  ${username}  Завантажити документ в ставку  ${file_path}  ${TENDER['TENDER_UAID']}
+  Set To Dictionary  ${USERS.users['${username}']}  bid_document=${bid_document_data}
   Remove File  ${file_path}
 
 
 Можливість змінити документацію цінової пропозиції користувачем ${username}
   ${file_path}  ${file_name}  ${file_content}=  create_fake_doc
-  ${docid}=  Get Variable Value  ${USERS.users['${username}'].bidresponses['bid_doc_upload']['upload_response'].data.id}
-  Run As  ${username}  Змінити документ в ставці  ${TENDER['TENDER_UAID']}  ${file_path}  ${docid}
+  ${doc_id}=  get_id_from_string  ${file_name}
+  ${bid_document_modified_data}=  Create Dictionary
+  ...      doc_name=${file_name}
+  ...      doc_content=${file_content}
+  ...      doc_id=${doc_id}
+  Run As  ${username}  Змінити документ в ставці  ${TENDER['TENDER_UAID']}  ${file_path}  ${USERS.users['${username}']['bid_document']['doc_id']}
+  Set To Dictionary  ${USERS.users['${username}']}  bid_document_modified=${bid_document_modified_data}
   Remove File  ${file_path}
 
 ##############################################################################################

--- a/op_robot_tests/tests_files/brokers/openprocurement_client.robot
+++ b/op_robot_tests/tests_files/brokers/openprocurement_client.robot
@@ -752,11 +752,12 @@ Library  openprocurement_client_helper.py
 
 
 Змінити документ в ставці
-  [Arguments]  ${username}  ${tender_uaid}  ${path}  ${docid}
+  [Arguments]  ${username}  ${tender_uaid}  ${path}  ${doc_id}
   ${bid_id}=  Get Variable Value   ${USERS.users['${username}'].bidresponses['bid'].data.id}
   ${tender}=  openprocurement_client.Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
   ${tender}=  set_access_key  ${tender}  ${USERS.users['${username}']['access_token']}
-  ${response}=  Call Method  ${USERS.users['${username}'].client}  update_bid_document  ${path}  ${tender}   ${bid_id}   ${docid}
+  ${bid_doc}=  get_document_by_id  ${tender.data}  ${doc_id}
+  ${response}=  Call Method  ${USERS.users['${username}'].client}  update_bid_document  ${path}  ${tender}   ${bid_id}   ${bid_doc['id']}
   ${uploaded_file} =  Create Dictionary
   ...      filepath=${path}
   ...      upload_response=${response}
@@ -765,11 +766,12 @@ Library  openprocurement_client_helper.py
 
 
 Змінити документацію в ставці
-  [Arguments]  ${username}  ${tender_uaid}  ${doc_data}  ${docid}
+  [Arguments]  ${username}  ${tender_uaid}  ${doc_data}  ${doc_id}
   ${bid_id}=  Get Variable Value   ${USERS.users['${username}'].bidresponses['bid'].data.id}
   ${tender}=  openprocurement_client.Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
   ${tender}=  set_access_key  ${tender}  ${USERS.users['${username}']['access_token']}
-  ${reply}=  Call Method  ${USERS.users['${username}'].client}  patch_bid_document   ${tender}   ${doc_data}   ${bid_id}   ${docid}
+  ${bid_doc}=  get_document_by_id  ${tender.data}  ${doc_id}
+  ${reply}=  Call Method  ${USERS.users['${username}'].client}  patch_bid_document   ${tender}   ${doc_data}   ${bid_id}   ${bid_doc['id']}
 
 
 Отримати пропозицію

--- a/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
+++ b/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
@@ -65,6 +65,10 @@ def get_document_by_id(data, doc_id):
         for document in cancellation.get('documents', []):
             if doc_id in document.get('title', ''):
                 return document
+    for bid in data.get('bids', []):
+        for document in bid.get('documents', []):
+            if doc_id in document.get('title', ''):
+                return document
     raise Exception('Document with id {} not found'.format(doc_id))
 
 


### PR DESCRIPTION
Cannot merge this, coz it's not working. There is must to have access token in get_tender() arguments from client.py.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/319)

<!-- Reviewable:end -->
