### PR TITLE
Implement parameters passing through command line

### DIFF
--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -68,7 +68,8 @@ Set Suite Variable With Default Value
 
   # Load brokers data
   ${file_path}=  Get Variable Value  ${BROKERS_FILE}  brokers.yaml
-  ${BROKERS}=  load_data_from  ${file_path}  mode=brokers
+  ${BROKERS_PARAMS}=  Get Variable Value  ${BROKERS_PARAMS}
+  ${BROKERS}=  load_data_from  ${file_path}  mode=brokers  external_params_name=BROKERS_PARAMS  external_params=${BROKERS_PARAMS}
   Log  ${BROKERS}
   Set Suite Variable  ${BROKERS}
   # List of currently used brokers
@@ -76,7 +77,8 @@ Set Suite Variable With Default Value
 
   # Load users data
   ${file_path}=  Get Variable Value  ${USERS_FILE}  users.yaml
-  ${USERS}=  load_data_from  ${file_path}
+  ${USERS_PARAMS}=  Get Variable Value  ${USERS_PARAMS}
+  ${USERS}=  load_data_from  ${file_path}  users.yaml  external_params_name=USERS_PARAMS  external_params=${USERS_PARAMS}
   Log  ${USERS.users}
   Set Suite Variable  ${USERS}
   # List of currently used users

--- a/op_robot_tests/tests_files/service_keywords.py
+++ b/op_robot_tests/tests_files/service_keywords.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 from dpath.util import new as xpathnew
 from haversine import haversine
 from iso8601 import parse_date
-from json import load
+from json import load, loads
 from jsonpath_rw import parse as parse_path
 from munch import fromYAML, Munch, munchify
 from robot.errors import ExecutionFailed
@@ -232,22 +232,37 @@ def munch_to_object(data, format="yaml"):
         return data.toYAML(allow_unicode=True, default_flow_style=False)
 
 
-def load_data_from(file_name, mode=None):
+def load_data_from(file_name, mode=None, external_params_name=None,
+                   external_params=None):
+    """we assume that 'external_params' is a json if passed"""
     if not os.path.exists(file_name):
         file_name = os.path.join(os.path.dirname(__file__), 'data', file_name)
     with open(file_name) as file_obj:
-        if file_name.endswith(".json"):
+        if file_name.endswith('.json'):
             file_data = Munch.fromDict(load(file_obj))
-        elif file_name.endswith(".yaml"):
+        elif file_name.endswith('.yaml'):
             file_data = fromYAML(file_obj)
-    if mode == "brokers":
+        converted_data = file_data
+    if mode == 'brokers':
         default = file_data.pop('Default')
         brokers = {}
         for k, v in file_data.iteritems():
             brokers[k] = merge_dicts(default, v)
-        return brokers
-    else:
-        return file_data
+        converted_data = brokers
+
+    try:
+        ext_params_munch \
+            = Munch.fromDict(loads(external_params)) \
+            if external_params else Munch()
+    except ValueError:
+        raise ValueError(
+            'Value {param} of command line parameter {name} is invalid'.
+            format(name=str(external_params_name), param=str(external_params))
+        )
+    except Exception as e:
+        raise e
+
+    return merge_dicts(converted_data, ext_params_munch)
 
 
 def compute_intrs(brokers_data, used_brokers):


### PR DESCRIPTION
Parameters defined in brokers.yaml and users.yaml can be overridden
through command line. Example of usage:
```json
-v BROKERS_PARAMS:'{"Quinta": {"intervals": {"default": {"enquiry": [0, 0], "tender": [0, 5.3]}}}}'
-v USERS_PARAMS:'{"users": {"Tender_Owner": {"api_key": "a"}}}'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/452)
<!-- Reviewable:end -->
