### PR TITLE
New variable for submissionMethodDetails

### DIFF
--- a/op_robot_tests/tests_files/initial_data.py
+++ b/op_robot_tests/tests_files/initial_data.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -
+import os
+import random
 from datetime import timedelta
+from tempfile import NamedTemporaryFile
+from uuid import uuid4
 from faker import Factory
 from faker.providers.company.en_US import Provider as CompanyProviderEnUs
 from faker.providers.company.ru_RU import Provider as CompanyProviderRuRu
 from munch import munchify
-from uuid import uuid4
-from tempfile import NamedTemporaryFile
-from .local_time import get_now
 from op_faker import OP_Provider
-import os
-import random
+from .local_time import get_now
 
 
 fake_en = Factory.create(locale='en_US')
@@ -116,7 +116,7 @@ def test_tender_data(params, periods=("enquiry", "tender")):
         if params.get('lot_meat'):
             new_feature = test_feature_data()
             new_feature['featureOf'] = "lot"
-            data['lots'][0]['id'] =  data['lots'][0].get('id', uuid4().hex)
+            data['lots'][0]['id'] = data['lots'][0].get('id', uuid4().hex)
             new_feature['relatedItem'] = data['lots'][0]['id']
             data['features'].append(new_feature)
     else:
@@ -130,7 +130,7 @@ def test_tender_data(params, periods=("enquiry", "tender")):
     if params.get('item_meat'):
         new_feature = test_feature_data()
         new_feature['featureOf'] = "item"
-        data['items'][0]['id'] =  data['items'][0].get('id', uuid4().hex)
+        data['items'][0]['id'] = data['items'][0].get('id', uuid4().hex)
         new_feature['relatedItem'] = data['items'][0]['id']
         data['features'].append(new_feature)
     if not data['features']:
@@ -315,9 +315,9 @@ def test_item_data(cpv=None):
     data["description_ru"] = field_with_id("i", data["description_ru"])
     days = fake.random_int(min=1, max=30)
     data["deliveryDate"] = {
-                            "startDate":(get_now() + timedelta(days=days)).isoformat(),
-                            "endDate":(get_now() + timedelta(days=days)).isoformat()
-                           }
+        "startDate": (get_now() + timedelta(days=days)).isoformat(),
+        "endDate": (get_now() + timedelta(days=days)).isoformat()
+    }
     data["deliveryAddress"]["countryName_en"] = translate_country_en(data["deliveryAddress"]["countryName"])
     data["deliveryAddress"]["countryName_ru"] = translate_country_ru(data["deliveryAddress"]["countryName"])
     return munchify(data)
@@ -369,7 +369,6 @@ def test_lot_data(max_value_amount):
 def test_lot_document_data(document, lot_id):
     document.data.update({"documentOf": "lot", "relatedItem": lot_id})
     return munchify(document)
-
 
 
 def test_tender_data_openua(params):

--- a/op_robot_tests/tests_files/initial_data.py
+++ b/op_robot_tests/tests_files/initial_data.py
@@ -56,12 +56,16 @@ def create_fake_doc():
     return tf.name.replace('\\', '\\\\'), os.path.basename(tf.name), content
 
 
-def test_tender_data(params, periods=("enquiry", "tender")):
+def test_tender_data(params,
+                     periods=("enquiry", "tender"),
+                     submissionMethodDetails=None):
+    submissionMethodDetails = submissionMethodDetails \
+        if submissionMethodDetails else "quick"
     now = get_now()
     value_amount = round(random.uniform(3000, 99999999999.99), 2)  # max value equals to budget of Ukraine in hryvnias
     data = {
         "mode": "test",
-        "submissionMethodDetails": "quick",
+        "submissionMethodDetails": submissionMethodDetails,
         "description": fake.description(),
         "description_en": fake_en.sentence(nb_words=10, variable_nb_words=True),
         "description_ru": fake_ru.sentence(nb_words=10, variable_nb_words=True),
@@ -371,21 +375,21 @@ def test_lot_document_data(document, lot_id):
     return munchify(document)
 
 
-def test_tender_data_openua(params):
+def test_tender_data_openua(params, submissionMethodDetails):
     # We should not provide any values for `enquiryPeriod` when creating
     # an openUA or openEU procedure. That field should not be present at all.
     # Therefore, we pass a nondefault list of periods to `test_tender_data()`.
-    data = test_tender_data(params, ('tender',))
+    data = test_tender_data(params, ('tender',), submissionMethodDetails)
     data['procurementMethodType'] = 'aboveThresholdUA'
     data['procuringEntity']['kind'] = 'general'
     return data
 
 
-def test_tender_data_openeu(params):
+def test_tender_data_openeu(params, submissionMethodDetails):
     # We should not provide any values for `enquiryPeriod` when creating
     # an openUA or openEU procedure. That field should not be present at all.
     # Therefore, we pass a nondefault list of periods to `test_tender_data()`.
-    data = test_tender_data(params, ('tender',))
+    data = test_tender_data(params, ('tender',), submissionMethodDetails)
     data['procurementMethodType'] = 'aboveThresholdEU'
     data['title_en'] = "[TESTING]"
     for item_number, item in enumerate(data['items']):
@@ -398,11 +402,11 @@ def test_tender_data_openeu(params):
     return data
 
 
-def test_tender_data_competitive_dialogue(params):
+def test_tender_data_competitive_dialogue(params, submissionMethodDetails):
     # We should not provide any values for `enquiryPeriod` when creating
     # an openUA or openEU procedure. That field should not be present at all.
     # Therefore, we pass a nondefault list of periods to `test_tender_data()`.
-    data = test_tender_data(params, ('tender',))
+    data = test_tender_data(params, ('tender',), submissionMethodDetails)
     if params.get('dialogue_type') == 'UA':
         data['procurementMethodType'] = 'competitiveDialogueUA'
     else:

--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -204,7 +204,8 @@ Get Broker Property By Username
 Підготувати дані для створення тендера
   [Arguments]  ${tender_parameters}
   ${period_intervals}=  compute_intrs  ${BROKERS}  ${used_brokers}
-  ${tender_data}=  prepare_test_tender_data  ${period_intervals}  ${tender_parameters}
+  ${submissionMethodDetails}=  Get Variable Value  ${submissionMethodDetails}
+  ${tender_data}=  prepare_test_tender_data  ${period_intervals}  ${tender_parameters}  ${submissionMethodDetails}
   ${TENDER}=  Create Dictionary
   Set Global Variable  ${TENDER}
   Log  ${tender_data}

--- a/op_robot_tests/tests_files/service_keywords.py
+++ b/op_robot_tests/tests_files/service_keywords.py
@@ -274,7 +274,9 @@ def compute_intrs(brokers_data, used_brokers):
     return result
 
 
-def prepare_test_tender_data(procedure_intervals, tender_parameters):
+def prepare_test_tender_data(procedure_intervals,
+                             tender_parameters,
+                             submissionMethodDetails):
     # Get actual intervals by mode name
     mode = tender_parameters['mode']
     if mode in procedure_intervals:
@@ -295,15 +297,22 @@ def prepare_test_tender_data(procedure_intervals, tender_parameters):
     elif mode == 'negotiation.quick':
         return munchify({'data': test_tender_data_limited(tender_parameters)})
     elif mode == 'openeu':
-        return munchify({'data': test_tender_data_openeu(tender_parameters)})
+        return munchify({'data': test_tender_data_openeu(
+            tender_parameters, submissionMethodDetails)})
     elif mode == 'openua':
-        return munchify({'data': test_tender_data_openua(tender_parameters)})
+        return munchify({'data': test_tender_data_openua(
+            tender_parameters, submissionMethodDetails)})
     elif mode == 'open_competitive_dialogue':
-        return munchify({'data': test_tender_data_competitive_dialogue(tender_parameters)})
+        return munchify({'data': test_tender_data_competitive_dialogue(
+            tender_parameters, submissionMethodDetails)})
     elif mode == 'reporting':
         return munchify({'data': test_tender_data_limited(tender_parameters)})
     elif mode == 'belowThreshold':
-        return munchify({'data': test_tender_data(tender_parameters)})
+        return munchify({'data': test_tender_data(
+            tender_parameters,
+            submissionMethodDetails=submissionMethodDetails)})
+        # The previous line needs an explicit keyword argument because,
+        # unlike previous functions, this one has three arguments.
     raise ValueError("Invalid mode for prepare_test_tender_data")
 
 

--- a/op_robot_tests/tests_files/service_keywords.py
+++ b/op_robot_tests/tests_files/service_keywords.py
@@ -6,7 +6,6 @@ from datetime import timedelta
 from dateutil.parser import parse
 from dpath.util import new as xpathnew
 from haversine import haversine
-from iso8601 import parse_date
 from json import load, loads
 from jsonpath_rw import parse as parse_path
 from munch import Munch, munchify


### PR DESCRIPTION
# New variable for submissionMethodDetails

This variable can be specified as a command line argument, e.g. `-v submissionMethodDetails:"quick"`. Currently supported values are listed [here](http://api-docs.openprocurement.org/en/latest/acceleration.html). If the variable is not set, the `submissionMethodDetails` field of the initial tender data falls back to its default value – `quick`. 

## Examples

### [belowThreshold with no-auction](https://lb.api-sandbox.openprocurement.org/api/2.3/tenders/02b2161483a74a28875aa7834838f3a8)

```bash
bin/op_tests -s openProcedure -A robot_tests_arguments/single_item_tender.txt -v submissionMethodDetails:"quick(mode:no-auction)"
```

### [belowThreshold with fast-forward](https://lb.api-sandbox.openprocurement.org/api/2.3/tenders/8adb25f49c724c9c9a2c6a7dd6be2bc4)

```bash
bin/op_tests -s openProcedure -A robot_tests_arguments/single_item_tender.txt -v submissionMethodDetails:"quick(mode:fast-forward)"
```

### [aboveThresholdUA](https://lb.api-sandbox.openprocurement.org/api/2.3/tenders/c8175bac12e541db887f7c35e6e0e671)

```bash
bin/op_tests -s openProcedure -A robot_tests_arguments/openua_testing.txt -v submissionMethodDetails:"quick(mode:fast-forward)"
```

### [aboveThresholdEU](https://lb.api-sandbox.openprocurement.org/api/2.3/tenders/390f1b6af05d405db594a81902dceef0)

```bash
bin/op_tests -s openProcedure -A robot_tests_arguments/openeu_testing.txt -v submissionMethodDetails:"quick(mode:fast-forward)"
```

### [competitiveDialogueUA](https://lb.api-sandbox.openprocurement.org/api/2.3/tenders/7ddc351ac7134851b97800880168a8be)

```bash
bin/op_tests -s openProcedure -A robot_tests_arguments/competitive_dialogue_simple.txt -v DIALOGUE_TYPE:UA -v submissionMethodDetails:"quick(mode:no-auction)"
```

### [competitiveDialogueEU](https://lb.api-sandbox.openprocurement.org/api/2.3/tenders/7cd1510f2c57402e92e0bedaac42e132)

```bash
bin/op_tests -s openProcedure -A robot_tests_arguments/competitive_dialogue_simple.txt -v submissionMethodDetails:"quick(mode:no-auction)"
```

I did not run the whole suite to check whether the auction was actually skipped or ran in the fast-forward mode, but I think that having the proper values in the `submissionMethodDetails` field is sufficient.

The `test_tender_data_limited` function was not modified because it ignores `submissionMethodDetails`.

+@kosaniak, +@lesiavl, please review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/500)
<!-- Reviewable:end -->
