### PR TITLE
Add sleep for 429

### DIFF
--- a/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
+++ b/op_robot_tests/tests_files/brokers/openprocurement_client_helper.py
@@ -1,8 +1,9 @@
 from openprocurement_client.client import Client, EDRClient
 from openprocurement_client.utils import get_tender_id_by_uaid
 from openprocurement_client.exceptions import IdNotFound
-from restkit.errors import RequestFailed, BadStatusLine
+from restkit.errors import RequestFailed, BadStatusLine, ResourceError
 from retrying import retry
+from time import sleep
 import os
 import urllib
 
@@ -32,7 +33,14 @@ class StableEDRClient(EDRClient):
     @retry(stop_max_attempt_number=100, wait_random_min=500,
            wait_random_max=4000, retry_on_exception=retry_if_request_failed)
     def request(self, *args, **kwargs):
-        return super(StableEDRClient, self).request(*args, **kwargs)
+        try:
+            res = super(StableEDRClient, self).request(*args, **kwargs)
+        except ResourceError as re:
+            if re.status_int == 429:
+                sleep(int(re.response.headers.get('Retry-After', '30')))
+            raise re
+        else:
+            return res
 
 
 def prepare_edr_wrapper(host_url, api_version, username, password):


### PR DESCRIPTION
Судячі з логів, помилка виникала при здійснені великої кількості запитів до ЄДР API, використовуючи 1 ключ. Додали sleep, у випадку коли отримуємо 429 Too many requests від ЄДР API.
[issue](https://github.com/openprocurement/robot_tests/issues/531)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/538)
<!-- Reviewable:end -->
