### PR TITLE
Изменение таймеров для трех площадок - uisce, zupb, ukin

### DIFF
--- a/op_robot_tests/tests_files/data/brokers.yaml
+++ b/op_robot_tests/tests_files/data/brokers.yaml
@@ -772,10 +772,10 @@ uisce:
         viewer:         uisce_Viewer
     intervals:
         default:
-            enquiry: [0, 10]
-            tender:  [0, 25]
-            auction: [25, 30]
-    timeout_on_wait: 10
+            enquiry: [0, 50]
+            tender:  [0, 50]
+            auction: [50, 75]
+    timeout_on_wait: 50
 zupb:
     keywords_file: zupb
     roles:
@@ -785,10 +785,10 @@ zupb:
         viewer:         zupb_Viewer
     intervals:
         default:
-            enquiry: [0, 10]
-            tender:  [0, 25]
-            auction: [25, 30]
-    timeout_on_wait: 10
+            enquiry: [0, 50]
+            tender:  [0, 50]
+            auction: [50, 75]
+    timeout_on_wait: 50
 epsilon:
     intervals:
         default:
@@ -893,7 +893,7 @@ ukin:
         viewer:         ukin_Viewer
     intervals:
         default:
-            enquiry: [0, 10]
-            tender:  [0, 25]
-            auction: [25, 30]
-    timeout_on_wait: 10
+            enquiry: [0, 50]
+            tender:  [0, 50]
+            auction: [50, 75]
+    timeout_on_wait: 50


### PR DESCRIPTION
Изменение параметров запуска тестировщика во избежание ошибок, связанных с задержками публикации аукционов на площадке.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/558)
<!-- Reviewable:end -->
