### PR TITLE
Three new esco scenarios

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -9,6 +9,8 @@ find-links =
 parts =
     scripts
 
+index = https://pypi.python.org/simple
+
 [scripts]
 recipe = zc.recipe.egg
 eggs =

--- a/op_robot_tests/tests_files/aboveThreshold_keywords.robot
+++ b/op_robot_tests/tests_files/aboveThreshold_keywords.robot
@@ -33,12 +33,11 @@ Resource           base_keywords.robot
 
 
 Можливість підтвердити цінову пропозицію учасником ${username}
-  ${status}=  Run Keyword IF  '${MODE}'=='openeu'  Set Variable  pending
-  ...                     ELSE IF  '${MODE}'=='openua' or '${MODE}'=='openua_defense'  Set Variable  active
+  ${status}=  Run Keyword IF  '${MODE}'=='esco'  Set Variable  pending
   Run As  ${username}  Змінити цінову пропозицію  ${TENDER['TENDER_UAID']}  status  ${status}
 
 ##############################################################################################
-#             OPENEU  Bid documentation
+#             ESCO  Bid documentation
 ##############################################################################################
 
 Можливість змінити документацію цінової пропозиції з публічної на приватну учасником ${username}
@@ -55,7 +54,7 @@ Resource           base_keywords.robot
   Remove File  ${file_path}
 
 ##############################################################################################
-#             OPENEU  Pre-Qualification
+#             ESCO  Pre-Qualification
 ##############################################################################################
 
 Можливість завантажити документ у кваліфікацію ${bid_index} пропозиції
@@ -70,6 +69,12 @@ Resource           base_keywords.robot
 
 Можливість скасувати рішення кваліфікації для ${bid_index} пропопозиції
   Run As  ${tender_owner}  Скасувати кваліфікацію  ${TENDER['TENDER_UAID']}  ${bid_index}
+
+
+Можливість підтвердити решту пропозицій кваліфікації
+  ${number_of_qualifications}=  Get Length  ${USERS.users['${tender_owner}'].tender_data.data.qualifications}
+  :FOR  ${bid_index}  IN RANGE  2  ${number_of_qualifications}+1
+  \  Можливість підтвердити ${bid_index} пропозицію кваліфікації
 
 
 Можливість підтвердити ${bid_index} пропозицію кваліфікації

--- a/op_robot_tests/tests_files/aboveThreshold_keywords.robot
+++ b/op_robot_tests/tests_files/aboveThreshold_keywords.robot
@@ -72,7 +72,7 @@ Resource           base_keywords.robot
 
 
 Можливість підтвердити решту пропозицій кваліфікації
-  ${number_of_qualifications}=  Get Length  ${USERS.users['${tender_owner}'].tender_data.data.qualifications}
+  ${number_of_qualifications}=  Run As  ${tender_owner}  Отримати кількість об'єктів  qualifications
   :FOR  ${bid_index}  IN RANGE  2  ${number_of_qualifications}+1
   \  Можливість підтвердити ${bid_index} пропозицію кваліфікації
 

--- a/op_robot_tests/tests_files/base_keywords.robot
+++ b/op_robot_tests/tests_files/base_keywords.robot
@@ -17,6 +17,7 @@ Resource           resource.robot
   ...      lot_meat=${${LOT_MEAT}}
   ...      item_meat=${${ITEM_MEAT}}
   ...      api_host_url=${API_HOST_URL}
+  ...      fundingKind=${FUNDING_KIND}
   ${DIALOGUE_TYPE}=  Get Variable Value  ${DIALOGUE_TYPE}
   Run keyword if  '${DIALOGUE_TYPE}' != '${None}'  Set to dictionary  ${tender_parameters}  dialogue_type=${DIALOGUE_TYPE}
   ${tender_data}=  Підготувати дані для створення тендера  ${tender_parameters}
@@ -1086,7 +1087,7 @@ Resource           resource.robot
 ##############################################################################################
 
 Можливість подати цінову пропозицію користувачем ${username}
-  ${bid}=  Підготувати дані для подання пропозиції
+  ${bid}=  Підготувати дані для подання пропозиції  ${username}
   ${bidresponses}=  Create Dictionary  bid=${bid}
   Set To Dictionary  ${USERS.users['${username}']}  bidresponses=${bidresponses}
   ${lots}=  Get Variable Value  ${USERS.users['${tender_owner}'].initial_data.data.lots}  ${None}
@@ -1116,7 +1117,7 @@ Resource           resource.robot
 
 
 Неможливість подати цінову пропозицію без прив’язки до лоту користувачем ${username}
-  ${bid}=  Підготувати дані для подання пропозиції
+  ${bid}=  Підготувати дані для подання пропозиції  ${username}
   ${values}=  Get Variable Value  ${bid.data.lotValues[0]}
   Remove From Dictionary  ${bid.data}  lotValues
   Set_To_Object  ${bid}  data  ${values}
@@ -1124,7 +1125,7 @@ Resource           resource.robot
 
 
 Неможливість подати цінову пропозицію без нецінових показників користувачем ${username}
-  ${bid}=  Підготувати дані для подання пропозиції
+  ${bid}=  Підготувати дані для подання пропозиції  ${username}
   Remove From Dictionary  ${bid.data}  parameters
   Require Failure  ${username}  Подати цінову пропозицію  ${TENDER['TENDER_UAID']}  ${bid}
 
@@ -1204,6 +1205,16 @@ Resource           resource.robot
   ...      ${TENDER['TENDER_UAID']}
   ...      ${0}
   Run Keyword And Ignore Error  Remove From Dictionary  ${USERS.users['${viewer}'].tender_data.data.contracts[0]}  status
+
+
+Неможливість змінити поле ${field_name} договору на значення ${new_value}
+  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${new_value}=  Run Keyword If  '${field_name}' == 'value.contractDuration.days' or '${field_name}' == 'value.contractDuration.years'  Convert To Integer  ${new_value}
+  ...  ELSE  Set Variable  ${new_value}
+  Run As  ${tender_owner}  Редагувати угоду  ${TENDER['TENDER_UAID']}  ${contract_index}  ${field_name}  ${new_value}
+  Remove From Dictionary  ${USERS.users['${viewer}'].tender_data.data.contracts[${contract_index}]}  ${field_name}
+  Run Keyword And Expect Error  *  Звірити відображення поля contracts[${contract_index}].${field_name} тендера із ${new_value} для користувача ${viewer}
 
 ##############################################################################################
 #             Pre-Qualifications

--- a/op_robot_tests/tests_files/base_keywords.robot
+++ b/op_robot_tests/tests_files/base_keywords.robot
@@ -1208,8 +1208,8 @@ Resource           resource.robot
 
 
 Неможливість змінити поле ${field_name} договору на значення ${new_value}
-  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${award_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  awards  active
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   ${new_value}=  Run Keyword If  '${field_name}' == 'value.contractDuration.days' or '${field_name}' == 'value.contractDuration.years'  Convert To Integer  ${new_value}
   ...  ELSE  Set Variable  ${new_value}
   Run As  ${tender_owner}  Редагувати угоду  ${TENDER['TENDER_UAID']}  ${contract_index}  ${field_name}  ${new_value}

--- a/op_robot_tests/tests_files/brokers/openprocurement_client.robot
+++ b/op_robot_tests/tests_files/brokers/openprocurement_client.robot
@@ -1460,3 +1460,13 @@ Library  openprocurement_client.utils
 Отримати кількість об'єктів
   [Arguments]  ${username}  ${field}
   Run Keyword And Return  Get Length  ${USERS.users['${username}'].tender_data.data.${field}}
+
+
+Отримати індекс елементу поля зі статусом
+  [Arguments]  ${username}  ${tender_uaid}  ${field_name}  ${status}
+  ${tender}=  openprocurement_client.Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
+  :FOR  ${index}  ${_}  IN ENUMERATE  @{tender.data.${field_name}}
+  \  ${field_status}=  Get From Dictionary  ${USERS.users['${username}'].tender_data.data.${field_name}[${index}]}  status
+  \  ${field_index}=  Set Variable If  '${field_status}' == '${status}'  ${index}
+  \  Exit For Loop If  '${field_status}' == '${status}'
+  [Return]  ${field_index}

--- a/op_robot_tests/tests_files/contract_signing.robot
+++ b/op_robot_tests/tests_files/contract_signing.robot
@@ -203,7 +203,7 @@ Suite Teardown  Test Suite Teardown
   [Tags]   ${USERS.users['${tender_owner}'].broker}: Процес укладання угоди
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
-  ...      contract_sign  level1
+  ...      contract_sign
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending

--- a/op_robot_tests/tests_files/contract_signing.robot
+++ b/op_robot_tests/tests_files/contract_signing.robot
@@ -26,7 +26,7 @@ Suite Teardown  Test Suite Teardown
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      tender_view
-  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
+  ${award_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  awards  active
   :FOR  ${username}  IN  ${viewer}  ${tender_owner}
   \  Отримати дані із тендера  ${username}  ${TENDER['TENDER_UAID']}  awards[${award_index}].complaintPeriod.endDate
 
@@ -36,7 +36,7 @@ Suite Teardown  Test Suite Teardown
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      contract_sign
-  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
+  ${award_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  awards  active
   ${standstillEnd}=  Get Variable Value  ${USERS.users['${tender_owner}'].tender_data.data.awards[${award_index}].complaintPeriod.endDate}
   Дочекатись дати  ${standstillEnd}
 
@@ -47,7 +47,7 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
+  ${award_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  awards  active
   Отримати дані із поля awards[${award_index}].value.amount тендера для користувача ${viewer}
 
 
@@ -113,7 +113,7 @@ Suite Teardown  Test Suite Teardown
   ...      modify_contract
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   ${dateSigned}=  create_fake_date
   Set to dictionary  ${USERS.users['${tender_owner}']}  dateSigned=${dateSigned}
   Run As  ${tender_owner}  Встановити дату підписання угоди  ${TENDER['TENDER_UAID']}  ${contract_index}  ${dateSigned}
@@ -125,7 +125,7 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   Звірити відображення поля contracts[${contract_index}].dateSigned тендера із ${USERS.users['${tender_owner}'].dateSigned} для користувача ${viewer}
 
 
@@ -136,7 +136,7 @@ Suite Teardown  Test Suite Teardown
   ...      modify_contract
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   ${startDate}=  create_fake_date
   ${endDate}=  add_minutes_to_date  ${startDate}  10
   Set to dictionary  ${USERS.users['${tender_owner}']}  contract_startDate=${startDate}  contract_endDate=${endDate}
@@ -149,7 +149,7 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   Звірити відображення поля contracts[${contract_index}].period.startDate тендера із ${USERS.users['${tender_owner}'].contract_startDate} для користувача ${viewer}
 
 
@@ -159,7 +159,7 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   Звірити відображення поля contracts[${contract_index}].period.endDate тендера із ${USERS.users['${tender_owner}'].contract_endDate} для користувача ${viewer}
 
 
@@ -170,7 +170,7 @@ Suite Teardown  Test Suite Teardown
   ...      add_doc_to_contract
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   Можливість завантажити документ в ${contract_index} угоду користувачем ${tender_owner}
 
 
@@ -206,7 +206,7 @@ Suite Teardown  Test Suite Teardown
   ...      contract_sign  level1
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  pending
   Run As  ${tender_owner}  Підтвердити підписання контракту  ${TENDER['TENDER_UAID']}  ${contract_index}
 
 
@@ -216,6 +216,6 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_sign
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати індекс поля contracts зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
+  ${contract_index}=  Run As  ${viewer}  Отримати індекс елементу поля зі статусом  ${TENDER['TENDER_UAID']}  contracts  active
   Run As  ${viewer}  Оновити сторінку з тендером  ${TENDER['TENDER_UAID']}
   Звірити відображення поля contracts[${contract_index}].status тендера із active для користувача ${viewer}

--- a/op_robot_tests/tests_files/contract_signing.robot
+++ b/op_robot_tests/tests_files/contract_signing.robot
@@ -26,7 +26,7 @@ Suite Teardown  Test Suite Teardown
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      tender_view
-  ${award_index}=  Отримати останній індекс  awards  ${viewer}
+  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
   :FOR  ${username}  IN  ${viewer}  ${tender_owner}
   \  Отримати дані із тендера  ${username}  ${TENDER['TENDER_UAID']}  awards[${award_index}].complaintPeriod.endDate
 
@@ -36,7 +36,7 @@ Suite Teardown  Test Suite Teardown
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      contract_sign
-  ${award_index}=  Отримати останній індекс  awards  ${viewer}
+  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
   ${standstillEnd}=  Get Variable Value  ${USERS.users['${tender_owner}'].tender_data.data.awards[${award_index}].complaintPeriod.endDate}
   Дочекатись дати  ${standstillEnd}
 
@@ -47,34 +47,63 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${award_index}=  Отримати останній індекс  awards  ${viewer}
+  ${award_index}=  Отримати індекс поля awards зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
   Отримати дані із поля awards[${award_index}].value.amount тендера для користувача ${viewer}
 
 
-Можливість редагувати вартість угоди
+Неможливість редагувати вартість угоди
   [Tags]   ${USERS.users['${tender_owner}'].broker}: Редагування угоди
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      modify_contract
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${award_index}=  Отримати останній індекс  awards  ${viewer}
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
-  ${award_amount}=  Get From Dictionary  ${USERS.users['${viewer}'].tender_data.data.awards[${award_index}].value}  amount
-  ${amount}=  create_fake_amount  ${award_amount}
-  Set to dictionary  ${USERS.users['${tender_owner}']}  new_amount=${amount}
-  Run As  ${tender_owner}  Редагувати угоду  ${TENDER['TENDER_UAID']}  ${contract_index}  value.amount  ${amount}
+  ${new_amount}=  create_fake_value_amount
+  Неможливість змінити поле value.amount договору на значення ${new_amount}
 
 
-Відображення відредагованої вартості угоди
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних угоди
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      contract_view
-  [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
-  Remove From Dictionary  ${USERS.users['${viewer}'].tender_data.data.contracts[${contract_index}].value}  amount
-  Звірити відображення поля contracts[${contract_index}].value.amount тендера із ${USERS.users['${tender_owner}'].new_amount} для користувача ${viewer}
+Неможливість редагувати показник ефективності енергосервісного договору
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Редагування угоди
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ...      modify_contract
+  [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
+  [Teardown]  Оновити LAST_MODIFICATION_DATE
+  ${new_amountPerformance}=  create_fake_value_amount
+  Неможливість змінити поле value.amountPerformance договору на значення ${new_amountPerformance}
+
+
+Неможливість редагувати щорічне скорочення витрат Замовника
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Редагування угоди
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ...      modify_contract
+  [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
+  [Teardown]  Оновити LAST_MODIFICATION_DATE
+  ${new_annualCostsReduction}=  create_fake_annual_cost
+  Неможливість змінити поле value.annualCostsReduction договору на значення ${new_annualCostsReduction}
+
+
+Неможливість редагувати дні строку дії договору
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Редагування угоди
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ...      modify_contract
+  [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
+  [Teardown]  Оновити LAST_MODIFICATION_DATE
+  ${new_contractDuration_days}=  create_fake_amount  364
+  Неможливість змінити поле value.contractDuration.days договору на значення ${new_contractDuration_days}
+
+
+Неможливість редагувати роки строку дії договору
+  [Tags]   ${USERS.users['${tender_owner}'].broker}: Редагування угоди
+  ...      tender_owner
+  ...      ${USERS.users['${tender_owner}'].broker}
+  ...      modify_contract
+  [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
+  [Teardown]  Оновити LAST_MODIFICATION_DATE
+  ${new_contractDuration_years}=  create_fake_amount  15
+  Неможливість змінити поле value.contractDuration.years договору на значення ${new_contractDuration_years}
 
 
 Можливість встановити дату підписання угоди
@@ -84,7 +113,7 @@ Suite Teardown  Test Suite Teardown
   ...      modify_contract
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
   ${dateSigned}=  create_fake_date
   Set to dictionary  ${USERS.users['${tender_owner}']}  dateSigned=${dateSigned}
   Run As  ${tender_owner}  Встановити дату підписання угоди  ${TENDER['TENDER_UAID']}  ${contract_index}  ${dateSigned}
@@ -96,7 +125,7 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
   Звірити відображення поля contracts[${contract_index}].dateSigned тендера із ${USERS.users['${tender_owner}'].dateSigned} для користувача ${viewer}
 
 
@@ -107,7 +136,7 @@ Suite Teardown  Test Suite Teardown
   ...      modify_contract
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
   ${startDate}=  create_fake_date
   ${endDate}=  add_minutes_to_date  ${startDate}  10
   Set to dictionary  ${USERS.users['${tender_owner}']}  contract_startDate=${startDate}  contract_endDate=${endDate}
@@ -120,7 +149,7 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
   Звірити відображення поля contracts[${contract_index}].period.startDate тендера із ${USERS.users['${tender_owner}'].contract_startDate} для користувача ${viewer}
 
 
@@ -130,7 +159,7 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_view
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
   Звірити відображення поля contracts[${contract_index}].period.endDate тендера із ${USERS.users['${tender_owner}'].contract_endDate} для користувача ${viewer}
 
 
@@ -141,7 +170,7 @@ Suite Teardown  Test Suite Teardown
   ...      add_doc_to_contract
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
   Можливість завантажити документ в ${contract_index} угоду користувачем ${tender_owner}
 
 
@@ -177,7 +206,7 @@ Suite Teardown  Test Suite Teardown
   ...      contract_sign  level1
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом pending ${viewer} ${TENDER['TENDER_UAID']}
   Run As  ${tender_owner}  Підтвердити підписання контракту  ${TENDER['TENDER_UAID']}  ${contract_index}
 
 
@@ -187,6 +216,6 @@ Suite Teardown  Test Suite Teardown
   ...      ${USERS.users['${viewer}'].broker}
   ...      contract_sign
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${contract_index}=  Отримати останній індекс  contracts  ${viewer}
+  ${contract_index}=  Отримати індекс поля contracts зі статусом active ${viewer} ${TENDER['TENDER_UAID']}
   Run As  ${viewer}  Оновити сторінку з тендером  ${TENDER['TENDER_UAID']}
   Звірити відображення поля contracts[${contract_index}].status тендера із active для користувача ${viewer}

--- a/op_robot_tests/tests_files/data/brokers.yaml
+++ b/op_robot_tests/tests_files/data/brokers.yaml
@@ -38,6 +38,9 @@ Default:
         openeu:
             accelerator: 1440
             tender:  [0, 30]
+        esco:
+            accelerator: 1440
+            tender:  [0, 30]
         openua_defense:
             accelerator: 1440
             tender:  [0, 6]
@@ -56,6 +59,9 @@ Quinta:
         openeu:
             tender:  [1, 35]
         openua_defense:
+            tender:  [0, 30]
+        esco:
+            accelerator: 1440
             tender:  [0, 30]
         open_competitive_dialogue:
             accelerator: 1440

--- a/op_robot_tests/tests_files/initial_data.py
+++ b/op_robot_tests/tests_files/initial_data.py
@@ -44,7 +44,7 @@ def create_fake_date():
 def create_fake_annual_cost():
     annual_cost = []
     for i in range(0, 21):
-        cost=str(float(round(random.uniform(1, 100), 2)))
+        cost=str(round(random.uniform(1, 100), 2))
         annual_cost.append(cost)
     return annual_cost
 
@@ -356,25 +356,26 @@ def test_bid_data():
 def test_bid_value(tender_data):
     annual_cost = []
     for i in range(0, 21):
-        cost=float(round(random.uniform(1, 100), 2))
+        cost=round(random.uniform(1, 100), 2)
         annual_cost.append(cost)
     if tender_data['fundingKind'] == "budget":
-        yearly_percentage=float(round(random.uniform(0.01, float(tender_data['yearlyPaymentsPercentageRange'])), 3))
+        yearly_percentage=round(random.uniform(0.01, float(tender_data['yearlyPaymentsPercentageRange'])), 5)
     else:
         yearly_percentage= 0.8
-    bid = munchify({
+    # when tender fundingKind is budget, yearlyPaymentsPercentageRange should be less or equal 0.8, and more or equal 0
+    # when tender fundingKind is other, yearlyPaymentsPercentageRange should be equal 0.8
+    return munchify({
         "value": {
             "currency": "UAH",
             "valueAddedTaxIncluded": True,
             "yearlyPaymentsPercentage": yearly_percentage,
             "annualCostsReduction": annual_cost,
             "contractDuration": {
-                "years": int(random.uniform(1, 15)),
-                "days": int(random.uniform(1, 364))
+                "years": random.randint(0, 15),
+                "days": random.randint(1, 364)
             }
         }
     })
-    return bid
 
 
 def test_supplier_data():
@@ -471,14 +472,14 @@ def test_tender_data_esco(params, submissionMethodDetails):
     data['procuringEntity']['contactPoint']['availableLanguage'] = "en"
     data['procuringEntity']['identifier']['legalName_en'] = fake_en.sentence(nb_words=10, variable_nb_words=True)
     data['procuringEntity']['kind'] = 'general'
-    data['minimalStepPercentage'] = float(round(random.uniform(0.015, 0.03), 5))
+    data['minimalStepPercentage'] = round(random.uniform(0.015, 0.03), 5)
     data['fundingKind'] = params['fundingKind']
-    data['NBUdiscountRate'] = float(round(random.uniform(0, 0.99), 5))
+    data['NBUdiscountRate'] = round(random.uniform(0, 0.99), 5)
     del data["value"]
     del data["minimalStep"]
     if params['number_of_lots'] == 0:
         if data['fundingKind'] == "budget":
-            data['yearlyPaymentsPercentageRange'] = float(round(random.uniform(0.01, 0.8), 3))
+            data['yearlyPaymentsPercentageRange'] = round(random.uniform(0.01, 0.8), 5)
         else:
             data['yearlyPaymentsPercentageRange'] = 0.8
     for index in range(params['number_of_lots']):
@@ -486,9 +487,9 @@ def test_tender_data_esco(params, submissionMethodDetails):
         if index == 0:
             data['lots'][index]['minimalStepPercentage'] = data['minimalStepPercentage']
         else:
-            data['lots'][index]['minimalStepPercentage'] = round((float(data['minimalStepPercentage'])-0.0002), 5)
+            data['lots'][index]['minimalStepPercentage'] = round(data['minimalStepPercentage'] - 0.0002, 5)
         if data['fundingKind'] == "budget":
-            data['lots'][index]['yearlyPaymentsPercentageRange'] = float(round(random.uniform(0.01, 0.8), 5))
+            data['lots'][index]['yearlyPaymentsPercentageRange'] = round(random.uniform(0.01, 0.8), 5)
         else:
             data['lots'][index]['yearlyPaymentsPercentageRange'] = 0.8
         del data['lots'][index]['value']

--- a/op_robot_tests/tests_files/initial_data.py
+++ b/op_robot_tests/tests_files/initial_data.py
@@ -30,7 +30,7 @@ def create_fake_sentence():
 
 
 def create_fake_amount(award_amount):
-    return round(random.uniform(1, award_amount), 2)
+    return round(random.uniform(1, float(award_amount)), 2)
 
 
 def create_fake_title():
@@ -39,6 +39,14 @@ def create_fake_title():
 
 def create_fake_date():
     return get_now().isoformat()
+
+
+def create_fake_annual_cost():
+    annual_cost = []
+    for i in range(0, 21):
+        cost=str(float(round(random.uniform(1, 100), 2)))
+        annual_cost.append(cost)
+    return annual_cost
 
 
 def subtraction(value1, value2):
@@ -172,56 +180,6 @@ def test_tender_data(params,
     if not data['features']:
         del data['features']
     data['status'] = 'draft'
-    return munchify(data)
-
-
-def test_tender_data_planning(params):
-    data = {
-        "budget": {
-            "amountNet": round(random.uniform(3000, 999999999.99), 2),
-            "description": fake.description(),
-            "project": {
-                "id": str(fake.random_int(min=1, max=999)),
-                "name": fake.description(),
-            },
-            "currency": "UAH",
-            "amount": round(random.uniform(3000, 99999999999.99), 2),
-            "id": str(fake.random_int(min=1, max=99999999999)) + "-" + str(fake.random_int(min=1, max=9)),
-        },
-        "procuringEntity": {
-            "identifier": {
-                "scheme": "UA-EDR",
-                "id": str(fake.random_int(min=1, max=999)),
-                "legalName": fake.description(),
-            },
-            "name": fake.description(),
-        },
-        "tender": {
-            "procurementMethod": "open",
-            "procurementMethodType": "belowThreshold",
-            "tenderPeriod": {
-                "startDate": (get_now().isoformat())
-            }
-        },
-        "items": []
-        }
-    id_cpv=fake.cpv()[:4]
-    cpv_data=test_item_data(id_cpv)
-    data.update(cpv_data)
-    del data['deliveryDate']
-    del data['description']
-    del data['description_en']
-    del data['description_ru']
-    del data['deliveryAddress']
-    del data['deliveryLocation']
-    del data['quantity']
-    del data['unit']
-    for i in range(params['number_of_items']):
-        item_data=test_item_data(id_cpv)
-        del item_data['deliveryAddress']
-        del item_data['deliveryLocation']
-        del item_data['deliveryDate']['startDate']
-        data['items'].append(item_data)
     return munchify(data)
 
 
@@ -395,14 +353,28 @@ def test_bid_data():
     return bid
 
 
-def test_bid_value(max_value_amount):
-    return munchify({
+def test_bid_value(tender_data):
+    annual_cost = []
+    for i in range(0, 21):
+        cost=float(round(random.uniform(1, 100), 2))
+        annual_cost.append(cost)
+    if tender_data['fundingKind'] == "budget":
+        yearly_percentage=float(round(random.uniform(0.01, float(tender_data['yearlyPaymentsPercentageRange'])), 3))
+    else:
+        yearly_percentage= 0.8
+    bid = munchify({
         "value": {
             "currency": "UAH",
-            "amount": round(random.uniform((0.95 * max_value_amount), max_value_amount), 2),
-            "valueAddedTaxIncluded": True
+            "valueAddedTaxIncluded": True,
+            "yearlyPaymentsPercentage": yearly_percentage,
+            "annualCostsReduction": annual_cost,
+            "contractDuration": {
+                "years": int(random.uniform(1, 15)),
+                "days": int(random.uniform(1, 364))
+            }
         }
     })
+    return bid
 
 
 def test_supplier_data():
@@ -488,60 +460,41 @@ def test_change_document_data(document, change_id):
     return munchify(document)
 
 
-def test_tender_data_openua(params, submissionMethodDetails):
-    # We should not provide any values for `enquiryPeriod` when creating
-    # an openUA or openEU procedure. That field should not be present at all.
-    # Therefore, we pass a nondefault list of periods to `test_tender_data()`.
+def test_tender_data_esco(params, submissionMethodDetails):
     data = test_tender_data(params, ('tender',), submissionMethodDetails)
-    data['procurementMethodType'] = 'aboveThresholdUA'
-    data['procuringEntity']['kind'] = 'general'
-    return data
-
-
-def test_tender_data_openua_defense(params, submissionMethodDetails):
-    """We should not provide any values for `enquiryPeriod` when creating
-    an openUA, openEU or openUA_defense procedure. That field should not be present at all.
-    Therefore, we pass a nondefault list of periods to `test_tender_data()`."""
-    data = test_tender_data(params, ('tender',), submissionMethodDetails)
-    data['procurementMethodType'] = 'aboveThresholdUA.defense'
-    data['procuringEntity']['kind'] = 'defense'
-    return data
-
-
-def test_tender_data_openeu(params, submissionMethodDetails):
-    # We should not provide any values for `enquiryPeriod` when creating
-    # an openUA or openEU procedure. That field should not be present at all.
-    # Therefore, we pass a nondefault list of periods to `test_tender_data()`.
-    data = test_tender_data(params, ('tender',), submissionMethodDetails)
-    data['procurementMethodType'] = 'aboveThresholdEU'
+    data['procurementMethodType'] = 'esco'
     data['title_en'] = "[TESTING]"
     for item_number, item in enumerate(data['items']):
         item['description_en'] = "Test item #{}".format(item_number)
     data['procuringEntity']['name_en'] = fake_en.name()
     data['procuringEntity']['contactPoint']['name_en'] = fake_en.name()
     data['procuringEntity']['contactPoint']['availableLanguage'] = "en"
-    data['procuringEntity']['identifier']['legalName_en'] = u"Institution \"Vinnytsia City Council primary and secondary general school № 10\""
-    data['procuringEntity']['kind'] = 'general'
-    return data
-
-
-def test_tender_data_competitive_dialogue(params, submissionMethodDetails):
-    # We should not provide any values for `enquiryPeriod` when creating
-    # an openUA or openEU procedure. That field should not be present at all.
-    # Therefore, we pass a nondefault list of periods to `test_tender_data()`.
-    data = test_tender_data(params, ('tender',), submissionMethodDetails)
-    if params.get('dialogue_type') == 'UA':
-        data['procurementMethodType'] = 'competitiveDialogueUA'
-    else:
-        data['procurementMethodType'] = 'competitiveDialogueEU'
-        data['procuringEntity']['contactPoint']['availableLanguage'] = "en"
-    data['title_en'] = "[TESTING] {}".format(fake_en.sentence(nb_words=3, variable_nb_words=True))
-    for item in data['items']:
-        item['description_en'] = fake_en.sentence(nb_words=3, variable_nb_words=True)
-    data['procuringEntity']['name_en'] = fake_en.name()
-    data['procuringEntity']['contactPoint']['name_en'] = fake_en.name()
     data['procuringEntity']['identifier']['legalName_en'] = fake_en.sentence(nb_words=10, variable_nb_words=True)
     data['procuringEntity']['kind'] = 'general'
+    data['minimalStepPercentage'] = float(round(random.uniform(0.015, 0.03), 5))
+    data['fundingKind'] = params['fundingKind']
+    data['NBUdiscountRate'] = float(round(random.uniform(0, 0.99), 5))
+    del data["value"]
+    del data["minimalStep"]
+    if params['number_of_lots'] == 0:
+        if data['fundingKind'] == "budget":
+            data['yearlyPaymentsPercentageRange'] = float(round(random.uniform(0.01, 0.8), 3))
+        else:
+            data['yearlyPaymentsPercentageRange'] = 0.8
+    for index in range(params['number_of_lots']):
+        data['lots'][index]['fundingKind'] = data['fundingKind']
+        if index == 0:
+            data['lots'][index]['minimalStepPercentage'] = data['minimalStepPercentage']
+        else:
+            data['lots'][index]['minimalStepPercentage'] = round((float(data['minimalStepPercentage'])-0.0002), 5)
+        if data['fundingKind'] == "budget":
+            data['lots'][index]['yearlyPaymentsPercentageRange'] = float(round(random.uniform(0.01, 0.8), 5))
+        else:
+            data['lots'][index]['yearlyPaymentsPercentageRange'] = 0.8
+        del data['lots'][index]['value']
+        del data['lots'][index]['minimalStep']
+    for index in range(params['number_of_items']):
+        del data['items'][index]['deliveryDate']
     return data
 
 

--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -988,14 +988,4 @@ Require Failure
   ${status}=  Run Keyword And Return Status  List Should Contain Value  ${USERS.users['${username}'].tender_data.data}  ${object}
   Run Keyword If  '${status}' == 'False'  Fail  ${object} not found in \${USERS.users['${username}'].tender_data.data}
   ${len_of_object}=  Get Length  ${USERS.users['${username}'].tender_data.data.${object}}
-  ${index}=  subtraction  ${len_of_object}  1
-  [Return]  ${index}
-
-
-Отримати індекс поля ${field_name} зі статусом ${status} ${username} ${tender_uaid}
-  ${tender}=  openprocurement_client.Пошук тендера по ідентифікатору  ${username}  ${tender_uaid}
-  :FOR  ${index}  ${_}  IN ENUMERATE  @{tender.data.${field_name}}
-  \  ${field_status}=  Get From Dictionary  ${USERS.users['${username}'].tender_data.data.${field_name}[${index}]}  status
-  \  ${field_index}=  Set Variable If  '${field_status}' == '${status}'  ${index}
-  \  Exit For Loop If  '${field_status}' == '${status}'
-  [Return]  ${field_index}
+  [Return]  ${len_of_object-1}

--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -537,7 +537,9 @@ Log differences between dicts
   ${left_lat}=  get_from_object  ${tender_data.data}  items[${item_index}].deliveryLocation.latitude
   ${left_lon}=  get_from_object  ${tender_data.data}  items[${item_index}].deliveryLocation.longitude
   ${right_lat}=  Отримати дані із тендера  ${username}  ${tender_uaid}  deliveryLocation.latitude  ${item_id}
+  ${right_lat}=  Convert To Number  ${right_lat}
   ${right_lon}=  Отримати дані із тендера  ${username}  ${tender_uaid}  deliveryLocation.longitude  ${item_id}
+  ${right_lon}=  Convert To Number  ${right_lon}
   Порівняти координати  ${left_lat}  ${left_lon}  ${right_lat}  ${right_lon}
 
 

--- a/op_robot_tests/tests_files/openProcedure.robot
+++ b/op_robot_tests/tests_files/openProcedure.robot
@@ -64,8 +64,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      critical
+  ...      tender_view
   Отримати дані із поля minimalStepPercentage тендера для усіх користувачів
 
 
@@ -73,8 +72,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      critical
+  ...      tender_view
   Звірити відображення поля NBUdiscountRate тендера для користувача ${viewer}
 
 
@@ -82,8 +80,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      critical
+  ...      tender_view
   Звірити відображення поля fundingKind тендера для користувача ${viewer}
 
 
@@ -91,8 +88,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      critical
+  ...      tender_view
   Отримати дані із поля yearlyPaymentsPercentageRange тендера для усіх користувачів
 
 
@@ -119,7 +115,6 @@ ${ITEM_MEAT}        ${True}
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
   ...      tender_view
-  ...      non-critical
   Run Keyword IF  'esco' in '${MODE}'
   ...      Отримати дані із поля enquiryPeriod.startDate тендера для усіх користувачів
   ...      ELSE
@@ -130,8 +125,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      critical
+  ...      tender_view
   Run Keyword IF  'esco' in '${MODE}'
   ...      Отримати дані із поля enquiryPeriod.endDate тендера для усіх користувачів
   ...      ELSE
@@ -160,8 +154,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      open_tender_view  level2
-  ...      non-critical
+  ...      open_tender_view
   Звірити відображення поля procurementMethodType тендера для усіх користувачів
 
 
@@ -314,8 +307,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      lot_view  level2
-  ...      critical
+  ...      lot_view
   Звірити відображення поля minimalStepPercentage усіх лотів для користувача ${viewer}
 
 
@@ -323,8 +315,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      lot_view  level2
-  ...      critical
+  ...      lot_view
   Звірити відображення поля fundingKind усіх лотів для користувача ${viewer}
 
 
@@ -332,8 +323,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      lot_view  level2
-  ...      critical
+  ...      lot_view
   Звірити відображення поля yearlyPaymentsPercentageRange усіх лотів для користувача ${viewer}
 
 ##############################################################################################
@@ -1383,7 +1373,6 @@ ${ITEM_MEAT}        ${True}
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
   ...      esco_make_bid_doc_private_by_provider
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість змінити документацію цінової пропозиції з публічної на приватну учасником ${provider}
 
@@ -1393,7 +1382,6 @@ ${ITEM_MEAT}        ${True}
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
   ...      esco_add_financial_bid_doc_by_provider
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити financial_documents документ до пропозиції учасником ${provider}
 
@@ -1403,7 +1391,6 @@ ${ITEM_MEAT}        ${True}
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
   ...      esco_add_qualification_bid_doc_by_provider
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити qualification_documents документ до пропозиції учасником ${provider}
 
@@ -1413,7 +1400,6 @@ ${ITEM_MEAT}        ${True}
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
   ...      esco_add_eligibility_bid_doc_by_provider
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити eligibility_documents документ до пропозиції учасником ${provider}
 
@@ -1640,7 +1626,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_add_doc_to_tender
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Run Keyword And Expect Error  *  Можливість додати документацію до тендера
 
@@ -1650,7 +1635,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_add_doc_to_lot
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Run Keyword And Expect Error  *  Можливість додати документацію до 0 лоту
 
@@ -1660,7 +1644,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_view
-  ...      non-critical
   [Setup]  Дочекатись дати початку періоду прекваліфікації  ${tender_owner}  ${TENDER['TENDER_UAID']}
   Звірити відображення поля qualifications[0].status тендера із pending для користувача ${tender_owner}
 
@@ -1670,7 +1653,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_view
-  ...      non-critical
   [Setup]  Дочекатись дати початку періоду прекваліфікації  ${tender_owner}  ${TENDER['TENDER_UAID']}
   Звірити відображення поля qualifications[1].status тендера із pending для користувача ${tender_owner}
 
@@ -1680,7 +1662,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_add_doc_to_first_bid
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити документ у кваліфікацію 0 пропозиції
 
@@ -1698,8 +1679,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${tender_owner}'].broker}: Кваліфікація
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
-  ...      pre-qualification_approve_first_bid  level1
-  ...      critical
+  ...      pre-qualification_approve_first_bid
   [Setup]  Дочекатись дати початку періоду прекваліфікації  ${tender_owner}  ${TENDER['TENDER_UAID']}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість підтвердити 0 пропозицію кваліфікації
@@ -1710,7 +1690,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_add_doc_to_second_bid
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити документ у кваліфікацію 1 пропозиції
 
@@ -1720,7 +1699,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_reject_second_bid
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість відхилити 1 пропозиції кваліфікації
 
@@ -1730,7 +1708,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_cancel_second_bid_qualification
-  ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість скасувати рішення кваліфікації для 1 пропопозиції
 
@@ -1739,8 +1716,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${tender_owner}'].broker}: Кваліфікація
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
-  ...      pre-qualification_approve_other_bids  level1
-  ...      critical
+  ...      pre-qualification_approve_other_bids
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість підтвердити решту пропозицій кваліфікації
 
@@ -1749,8 +1725,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${tender_owner}'].broker}: Кваліфікація
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
-  ...      pre-qualification_approve_qualifications  level1
-  ...      critical
+  ...      pre-qualification_approve_qualifications
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість затвердити остаточне рішення кваліфікації
@@ -1761,7 +1736,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_view
-  ...      non-critical
   [Setup]  Дочекатись синхронізації з майданчиком  ${tender_owner}
   Звірити статус тендера  ${tender_owner}  ${TENDER['TENDER_UAID']}  active.pre-qualification.stand-still
 
@@ -1771,7 +1745,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
   ...      pre-qualification_view
-  ...      non-critical
   [Teardown]  Дочекатись дати закінчення періоду прекваліфікації  ${tender_owner}  ${TENDER['TENDER_UAID']}
   Отримати дані із поля qualificationPeriod.endDate тендера для усіх користувачів
 

--- a/op_robot_tests/tests_files/openProcedure.robot
+++ b/op_robot_tests/tests_files/openProcedure.robot
@@ -6,7 +6,7 @@ Suite Teardown  Test Suite Teardown
 
 
 *** Variables ***
-${MODE}             openeu
+${MODE}             esco
 @{USED_ROLES}       tender_owner  provider  provider1  provider2  viewer
 ${DIALOGUE_TYPE}    EU
 
@@ -60,31 +60,40 @@ ${ITEM_MEAT}        ${True}
   Звірити відображення поля description тендера для користувача ${viewer}
 
 
-Відображення бюджету тендера
+Відображення мінімального кроку підвищення показника ефективності енергосервісного договору тендера
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level1
+  ...      tender_view  level2
   ...      critical
-  Звірити відображення поля value.amount тендера для усіх користувачів
+  Отримати дані із поля minimalStepPercentage тендера для усіх користувачів
 
 
-Відображення валюти тендера
+Відображення облікової ставки НБУ
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
   ...      tender_view  level2
-  ...      non-critical
-  Звірити відображення поля value.currency тендера для користувача ${viewer}
+  ...      critical
+  Звірити відображення поля NBUdiscountRate тендера для користувача ${viewer}
 
 
-Відображення ПДВ в бюджеті тендера
+Відображення джерела фінансування закупівлі
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
   ...      tender_view  level2
-  ...      non-critical
-  Звірити відображення поля value.valueAddedTaxIncluded тендера для користувача ${viewer}
+  ...      critical
+  Звірити відображення поля fundingKind тендера для користувача ${viewer}
+
+
+Відображення фіксованого відсотка суми скорочення витрат замовника тендера
+  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
+  ...      viewer
+  ...      ${USERS.users['${viewer}'].broker}
+  ...      tender_view  level2
+  ...      critical
+  Отримати дані із поля yearlyPaymentsPercentageRange тендера для усіх користувачів
 
 
 Відображення ідентифікатора тендера
@@ -111,7 +120,7 @@ ${ITEM_MEAT}        ${True}
   ...      ${USERS.users['${viewer}'].broker}
   ...      tender_view
   ...      non-critical
-  Run Keyword IF  'open' in '${MODE}'
+  Run Keyword IF  'esco' in '${MODE}'
   ...      Отримати дані із поля enquiryPeriod.startDate тендера для усіх користувачів
   ...      ELSE
   ...      Звірити відображення дати enquiryPeriod.startDate тендера для усіх користувачів
@@ -123,7 +132,7 @@ ${ITEM_MEAT}        ${True}
   ...      ${USERS.users['${viewer}'].broker}
   ...      tender_view  level2
   ...      critical
-  Run Keyword IF  'open' in '${MODE}'
+  Run Keyword IF  'esco' in '${MODE}'
   ...      Отримати дані із поля enquiryPeriod.endDate тендера для усіх користувачів
   ...      ELSE
   ...      Звірити відображення дати enquiryPeriod.endDate тендера для усіх користувачів
@@ -145,15 +154,6 @@ ${ITEM_MEAT}        ${True}
   ...      tender_view  level2
   ...      critical
   Звірити відображення дати tenderPeriod.endDate тендера для усіх користувачів
-
-
-Відображення мінімального кроку тендера
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення основних даних тендера
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      critical
-  Звірити відображення поля minimalStep.amount тендера для користувача ${viewer}
 
 
 Відображення типу оголошеного тендера
@@ -184,23 +184,6 @@ ${ITEM_MEAT}        ${True}
   ...      critical
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
   Звірити відображення поля description усіх предметів для усіх користувачів
-
-Відображення дати початку доставки номенклатур тендера
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення номенклатури тендера
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      non-critical
-  Звірити відображення дати deliveryDate.startDate усіх предметів для користувача ${viewer}
-
-
-Відображення дати кінця доставки номенклатур тендера
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення номенклатури тендера
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      non-critical
-  Звірити відображення дати deliveryDate.endDate усіх предметів для користувача ${viewer}
 
 
 Відображення координати доставки номенклатур тендера
@@ -304,15 +287,6 @@ ${ITEM_MEAT}        ${True}
   ...      non-critical
   Звірити відображення поля unit.code усіх предметів для користувача ${viewer}
 
-
-Відображення кількості номенклатур тендера
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення номенклатури тендера
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      tender_view  level2
-  ...      non-critical
-  Звірити відображення поля quantity усіх предметів для користувача ${viewer}
-
 ##############################################################################################
 #             Відображення основних даних лоту
 ##############################################################################################
@@ -336,58 +310,31 @@ ${ITEM_MEAT}        ${True}
   Звірити відображення поля description усіх лотів для користувача ${viewer}
 
 
-Відображення бюджету лотів
+Відображення мінімального кроку підвищення показника ефективності енергосервісного договору лота
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
   ...      lot_view  level2
   ...      critical
-  Звірити відображення поля value.amount усіх лотів для усіх користувачів
+  Звірити відображення поля minimalStepPercentage усіх лотів для користувача ${viewer}
 
 
-Відображення валюти лотів
+Відображення джерела фінансування лота
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
   ...      lot_view  level2
-  ...      non-critical
-  Звірити відображення поля value.currency усіх лотів для користувача ${viewer}
+  ...      critical
+  Звірити відображення поля fundingKind усіх лотів для користувача ${viewer}
 
 
-Відображення ПДВ в бюджеті лотів
+Відображення фіксованого відсотка суми скорочення витрат замовника лота
   [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
   ...      viewer
   ...      ${USERS.users['${viewer}'].broker}
   ...      lot_view  level2
-  ...      non-critical
-  Звірити відображення поля value.valueAddedTaxIncluded усіх лотів для користувача ${viewer}
-
-
-Відображення мінімального кроку лотів
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      lot_view  level2
-  ...      non-critical
-  Звірити відображення поля minimalStep.amount усіх лотів для усіх користувачів
-
-
-Відображення валюти мінімального кроку лотів
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      lot_view  level2
-  ...      non-critical
-  Звірити відображення поля minimalStep.currency усіх лотів для користувача ${viewer}
-
-
-Відображення ПДВ в мінімальному кроці лотів
-  [Tags]   ${USERS.users['${viewer}'].broker}: Відображення лоту тендера
-  ...      viewer
-  ...      ${USERS.users['${viewer}'].broker}
-  ...      lot_view  level2
-  ...      non-critical
-  Звірити відображення поля minimalStep.valueAddedTaxIncluded усіх лотів для користувача ${viewer}
+  ...      critical
+  Звірити відображення поля yearlyPaymentsPercentageRange усіх лотів для користувача ${viewer}
 
 ##############################################################################################
 #             Відображення основних даних предмету
@@ -537,26 +484,6 @@ ${ITEM_MEAT}        ${True}
   ...      add_lot_doc  level2
   ...      critical
   Звірити відображення вмісту документації до всіх лотів для користувача ${viewer}
-
-
-Можливість зменшити бюджет лоту
-  [Tags]   ${USERS.users['${tender_owner}'].broker}: Редагування тендера
-  ...      tender_owner
-  ...      ${USERS.users['${tender_owner}'].broker}
-  ...      modify_lot_value_amount  level2
-  ...      non-critical
-  [Teardown]  Оновити LAST_MODIFICATION_DATE
-  Можливість змінити на 99 відсотки бюджет 0 лоту
-
-
-Можливість збільшити бюджет лоту
-  [Tags]   ${USERS.users['${tender_owner}'].broker}: Редагування тендера
-  ...      tender_owner
-  ...      ${USERS.users['${tender_owner}'].broker}
-  ...      modify_lot_value_amount  level3
-  ...      non-critical
-  [Teardown]  Оновити LAST_MODIFICATION_DATE
-  Можливість змінити на 101 відсотки бюджет 0 лоту
 
 
 Можливість створення лоту із прив’язаним предметом закупівлі
@@ -1183,7 +1110,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]  ${USERS.users['${viewer}'].broker}: Відображення оскарження
   ...  viewer
   ...  ${USERS.users['${viewer}'].broker}
-  ...  create_tender_claim
+  ...  create_lot_claim
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
   Звірити відображення поля complaintID вимоги про виправлення умов 0 лоту із ${USERS.users['${provider}'].lot_claim_data.complaintID} для користувача ${viewer}
 
@@ -1455,7 +1382,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${provider}'].broker}: Подання пропозиції
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
-  ...      openeu_make_bid_doc_private_by_provider
+  ...      esco_make_bid_doc_private_by_provider
   ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість змінити документацію цінової пропозиції з публічної на приватну учасником ${provider}
@@ -1465,7 +1392,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${provider}'].broker}: Подання пропозиції
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
-  ...      openeu_add_financial_bid_doc_by_provider
+  ...      esco_add_financial_bid_doc_by_provider
   ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити financial_documents документ до пропозиції учасником ${provider}
@@ -1475,7 +1402,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${provider}'].broker}: Подання пропозиції
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
-  ...      openeu_add_qualification_bid_doc_by_provider
+  ...      esco_add_qualification_bid_doc_by_provider
   ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити qualification_documents документ до пропозиції учасником ${provider}
@@ -1485,7 +1412,7 @@ ${ITEM_MEAT}        ${True}
   [Tags]   ${USERS.users['${provider}'].broker}: Подання пропозиції
   ...      provider
   ...      ${USERS.users['${provider}'].broker}
-  ...      openeu_add_eligibility_bid_doc_by_provider
+  ...      esco_add_eligibility_bid_doc_by_provider
   ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
   Можливість завантажити eligibility_documents документ до пропозиції учасником ${provider}
@@ -1705,7 +1632,7 @@ ${ITEM_MEAT}        ${True}
 
 
 ##############################################################################################
-#             OPENEU  Pre-Qualification
+#             ESCO  Pre-Qualification
 ##############################################################################################
 
 Неможливість додати документацію до тендера під час кваліфікації
@@ -1808,24 +1735,14 @@ ${ITEM_MEAT}        ${True}
   Можливість скасувати рішення кваліфікації для 1 пропопозиції
 
 
-Можливість підтвердити другу пропозицію кваліфікації
+Можливість підтвердити решту пропозицій кваліфікації
   [Tags]   ${USERS.users['${tender_owner}'].broker}: Кваліфікація
   ...      tender_owner
   ...      ${USERS.users['${tender_owner}'].broker}
-  ...      pre-qualification_approve_second_bid  level1
+  ...      pre-qualification_approve_other_bids  level1
   ...      critical
   [Teardown]  Оновити LAST_MODIFICATION_DATE
-  Можливість підтвердити -1 пропозицію кваліфікації
-
-
-Можливість підтвердити третю пропозицію кваліфікації
-  [Tags]   ${USERS.users['${tender_owner}'].broker}: Кваліфікація
-  ...      tender_owner
-  ...      ${USERS.users['${tender_owner}'].broker}
-  ...      pre-qualification_approve_third_bid  level1
-  ...      critical
-  [Teardown]  Оновити LAST_MODIFICATION_DATE
-  Можливість підтвердити -2 пропозицію кваліфікації
+  Можливість підтвердити решту пропозицій кваліфікації
 
 
 Можливість затвердити остаточне рішення кваліфікації

--- a/op_robot_tests/tests_files/qualification.robot
+++ b/op_robot_tests/tests_files/qualification.robot
@@ -315,3 +315,7 @@ ${award_index}      ${0}
   ${awards_to_rejects}=  Run As  ${username}  Отримати кількість об'єктів  awards
   :FOR  ${award_index}  IN RANGE  2  ${awards_to_rejects*2-2}
   \  Run As  ${username}  Дискваліфікувати постачальника  ${TENDER['TENDER_UAID']}  ${award_index}
+
+# Award[0] and award[1] are activated. Then the latter is cancelled and reappears in 'pending' status.
+# After each 'pending' award is cancelled, another award of the same lot, but another bidder appears.
+# Thus, cancelling 'pending' awards, the number of awards to cancel is doubled. Award [2] is already cancelled.

--- a/op_robot_tests/tests_files/qualification.robot
+++ b/op_robot_tests/tests_files/qualification.robot
@@ -88,7 +88,7 @@ ${award_index}      ${0}
   ...  viewer
   ...  ${USERS.users['${viewer}'].broker}
   ...  create_award_claim
-  ${status}=  Set variable if  'open' in '${MODE}'  pending  claim
+  ${status}=  Set variable if  'esco' in '${MODE}'  pending  claim
   Звірити відображення поля status вимоги про виправлення визначення ${award_index} переможця із ${status} для користувача ${viewer}
 
 
@@ -196,7 +196,7 @@ ${award_index}      ${0}
   ...  ${USERS.users['${viewer}'].broker}
   ...  cancel_award_claim
   [Setup]  Дочекатись синхронізації з майданчиком  ${viewer}
-  ${status}=  Set variable if  'open' in '${MODE}'  stopping  cancelled
+  ${status}=  Set variable if  'esco' in '${MODE}'  stopping  cancelled
   Звірити відображення поля status вимоги про виправлення визначення ${award_index} переможця із ${status} для користувача ${viewer}
 
 
@@ -219,6 +219,7 @@ ${award_index}      ${0}
   [Setup]  Дочекатись дати початку періоду кваліфікації  ${tender_owner}  ${TENDER['TENDER_UAID']}
   Дочекатися перевірки кваліфікацій  ${tender_owner}  ${TENDER['TENDER_UAID']}
 
+# The following test cases are used in one-lot procedures.
 
 Можливість завантажити документ рішення кваліфікаційної комісії для підтвердження постачальника
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
@@ -242,11 +243,38 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_cancel_first_award_qualification  level1
+  ...  qualification_cancel_first_award  level1
   Run As  ${tender_owner}  Скасування рішення кваліфікаційної комісії  ${TENDER['TENDER_UAID']}  0
 
 
+Можливість відхилити постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  qualification_reject_second_award  level1
+  Run As  ${tender_owner}  Дискваліфікувати постачальника  ${TENDER['TENDER_UAID']}  1
+
+
 Можливість завантажити документ рішення кваліфікаційної комісії для підтвердження нового постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  qualification_add_doc_to_third_award  level3
+  ${file_path}  ${file_name}  ${file_content}=   create_fake_doc
+  Run As   ${tender_owner}   Завантажити документ рішення кваліфікаційної комісії   ${file_path}   ${TENDER['TENDER_UAID']}   2
+  Remove File  ${file_path}
+
+
+Можливість підтвердити нового постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  qualification_approve_third_award  level1
+  Run As  ${tender_owner}  Підтвердити постачальника  ${TENDER['TENDER_UAID']}  2
+
+# The following test cases are used in multi-lot procedures.
+
+Можливість завантажити документ рішення кваліфікаційної комісії для підтвердження другого постачальника
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
@@ -256,9 +284,34 @@ ${award_index}      ${0}
   Remove File  ${file_path}
 
 
-Можливість підтвердити нового постачальника
+Можливість підтвердити другого постачальника
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
   ...  qualification_approve_second_award  level1
   Run As  ${tender_owner}  Підтвердити постачальника  ${TENDER['TENDER_UAID']}  1
+
+
+Можливість скасувати рішення кваліфікації для другого постачальника
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  qualification_cancel_second_award  level1
+  Run As  ${tender_owner}  Скасування рішення кваліфікаційної комісії  ${TENDER['TENDER_UAID']}  1
+
+
+Можливість відхилити решту постачальників
+  [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
+  ...  tender_owner
+  ...  ${USERS.users['${tender_owner}'].broker}
+  ...  qualification_reject_other_awards  level1
+  Можливість дискваліфікувати решту постачальників  ${tender_owner}  ${TENDER['TENDER_UAID']}
+
+
+*** Keywords ***
+Можливість дискваліфікувати решту постачальників
+  [Arguments]  ${username}  ${tender_uaid}
+  Run as  ${username}  Пошук тендера по ідентифікатору  ${TENDER['TENDER_UAID']}
+  ${awards_to_rejects}=  Run As  ${username}  Отримати кількість об'єктів  awards
+  :FOR  ${award_index}  IN RANGE  2  ${awards_to_rejects*2-2}
+  \  Run As  ${username}  Дискваліфікувати постачальника  ${TENDER['TENDER_UAID']}  ${award_index}

--- a/op_robot_tests/tests_files/qualification.robot
+++ b/op_robot_tests/tests_files/qualification.robot
@@ -225,7 +225,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_add_doc_to_first_award  level3
+  ...  qualification_add_doc_to_first_award
   ${file_path}  ${file_name}  ${file_content}=   create_fake_doc
   Run As   ${tender_owner}   Завантажити документ рішення кваліфікаційної комісії   ${file_path}   ${TENDER['TENDER_UAID']}   0
   Remove File  ${file_path}
@@ -235,7 +235,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_approve_first_award  level1
+  ...  qualification_approve_first_award
   Run As  ${tender_owner}  Підтвердити постачальника  ${TENDER['TENDER_UAID']}  0
 
 
@@ -243,7 +243,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_cancel_first_award  level1
+  ...  qualification_cancel_first_award
   Run As  ${tender_owner}  Скасування рішення кваліфікаційної комісії  ${TENDER['TENDER_UAID']}  0
 
 
@@ -251,7 +251,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_reject_second_award  level1
+  ...  qualification_reject_second_award
   Run As  ${tender_owner}  Дискваліфікувати постачальника  ${TENDER['TENDER_UAID']}  1
 
 
@@ -259,7 +259,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_add_doc_to_third_award  level3
+  ...  qualification_add_doc_to_third_award
   ${file_path}  ${file_name}  ${file_content}=   create_fake_doc
   Run As   ${tender_owner}   Завантажити документ рішення кваліфікаційної комісії   ${file_path}   ${TENDER['TENDER_UAID']}   2
   Remove File  ${file_path}
@@ -269,7 +269,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_approve_third_award  level1
+  ...  qualification_approve_third_award
   Run As  ${tender_owner}  Підтвердити постачальника  ${TENDER['TENDER_UAID']}  2
 
 # The following test cases are used in multi-lot procedures.
@@ -278,7 +278,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_add_doc_to_second_award  level3
+  ...  qualification_add_doc_to_second_award
   ${file_path}  ${file_name}  ${file_content}=   create_fake_doc
   Run As   ${tender_owner}   Завантажити документ рішення кваліфікаційної комісії   ${file_path}   ${TENDER['TENDER_UAID']}   1
   Remove File  ${file_path}
@@ -288,7 +288,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_approve_second_award  level1
+  ...  qualification_approve_second_award
   Run As  ${tender_owner}  Підтвердити постачальника  ${TENDER['TENDER_UAID']}  1
 
 
@@ -296,7 +296,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_cancel_second_award  level1
+  ...  qualification_cancel_second_award
   Run As  ${tender_owner}  Скасування рішення кваліфікаційної комісії  ${TENDER['TENDER_UAID']}  1
 
 
@@ -304,7 +304,7 @@ ${award_index}      ${0}
   [Tags]  ${USERS.users['${tender_owner}'].broker}: Процес кваліфікації
   ...  tender_owner
   ...  ${USERS.users['${tender_owner}'].broker}
-  ...  qualification_reject_other_awards  level1
+  ...  qualification_reject_other_awards
   Можливість дискваліфікувати решту постачальників  ${tender_owner}  ${TENDER['TENDER_UAID']}
 
 

--- a/op_robot_tests/tests_files/resource.robot
+++ b/op_robot_tests/tests_files/resource.robot
@@ -1,9 +1,9 @@
 *** Variables ***
 ${RESOURCE}      tenders   # possible values: tenders, auctions
-${API_HOST_URL}  https://lb.api-sandbox.openprocurement.org
-${API_VERSION}   2.3
+${API_HOST_URL}  https://api-sandbox.prozorro.openprocurement.net
+${API_VERSION}   dev
 ${BROKER}        Quinta
-${DS_HOST_URL}   https://upload.docs-sandbox.openprocurement.org
+${DS_HOST_URL}   https://upload.docs-sandbox.prozorro.openprocurement.net
 ${ROLE}          viewer
 ${EDR_HOST_URL}  https://lb.edr-sandbox.openprocurement.org
 ${EDR_VERSION}   0

--- a/op_robot_tests/tests_files/service_keywords.py
+++ b/op_robot_tests/tests_files/service_keywords.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -
 import operator
+import random
 from .local_time import get_now, TZ
 from copy import deepcopy
 from datetime import timedelta
@@ -21,6 +22,7 @@ from .initial_data import (
     create_fake_sentence,
     create_fake_amount,
     create_fake_date,
+    create_fake_annual_cost,
     fake,
     subtraction,
     field_with_id,
@@ -42,12 +44,7 @@ from .initial_data import (
     test_question_data,
     test_supplier_data,
     test_tender_data,
-    test_tender_data_competitive_dialogue,
-    test_tender_data_limited,
-    test_tender_data_openeu,
-    test_tender_data_openua,
-    test_tender_data_planning,
-    test_tender_data_openua_defense,
+    test_tender_data_esco,
     test_bid_competitive_data,
     create_fake_title,
     create_fake_value_amount,
@@ -314,30 +311,8 @@ def prepare_test_tender_data(procedure_intervals,
         return munchify({'data': test_tender_data_limited(tender_parameters)})
     elif mode == 'negotiation.quick':
         return munchify({'data': test_tender_data_limited(tender_parameters)})
-    elif mode == 'openeu':
-        return munchify({'data': test_tender_data_openeu(
-            tender_parameters, submissionMethodDetails)})
-    elif mode == 'openua':
-        return munchify({'data': test_tender_data_openua(
-            tender_parameters, submissionMethodDetails)})
-    elif mode == 'openua_defense':
-        return munchify({'data': test_tender_data_openua_defense(
-            tender_parameters, submissionMethodDetails)})
-    elif mode == 'open_competitive_dialogue':
-        return munchify({'data': test_tender_data_competitive_dialogue(
-            tender_parameters, submissionMethodDetails)})
-    elif mode == 'reporting':
-        return munchify({'data': test_tender_data_limited(tender_parameters)})
-    elif mode == 'belowThreshold':
-        return munchify({'data': test_tender_data(
-            tender_parameters,
-            submissionMethodDetails=submissionMethodDetails,
-            accelerator=accelerator)})
-    elif mode == 'planning':
-        return munchify({'data': test_tender_data_planning(
-            tender_parameters)})
-        # The previous line needs an explicit keyword argument because,
-        # unlike previous functions, this one has three arguments.
+    elif mode == 'esco':
+        return munchify({'data': test_tender_data_esco(tender_parameters, submissionMethodDetails)})
     raise ValueError("Invalid mode for prepare_test_tender_data")
 
 
@@ -520,11 +495,7 @@ def get_object_by_id(data, given_object_id, slice_element, object_id):
 
 def generate_test_bid_data(tender_data):
     if tender_data.get('procurementMethodType', '') in (
-            'aboveThresholdUA',
-            'aboveThresholdUA.defense',
-            'aboveThresholdEU',
-            'competitiveDialogueUA',
-            'competitiveDialogueEU'
+            'esco'
         ):
         bid = test_bid_competitive_data()
         bid.data.selfEligible = True
@@ -534,11 +505,12 @@ def generate_test_bid_data(tender_data):
     if 'lots' in tender_data:
         bid.data.lotValues = []
         for lot in tender_data['lots']:
-            value = test_bid_value(lot['value']['amount'])
+            value = test_bid_value(tender_data)
             value['relatedLot'] = lot.get('id', '')
             bid.data.lotValues.append(value)
     else:
-        bid.data.update(test_bid_value(tender_data['value']['amount']))
+        value = test_bid_value(tender_data)
+        bid.data.update(value)
     if 'features' in tender_data:
         bid.data.parameters = []
         for feature in tender_data['features']:
@@ -586,4 +558,3 @@ def convert_amount_string_to_float(amount_string):
 
 def compare_rationale_types(type1, type2):
     return set(type1) == set(type2)
-

--- a/robot_tests_arguments/esco_meat_one_lot_budget.txt
+++ b/robot_tests_arguments/esco_meat_one_lot_budget.txt
@@ -1,0 +1,127 @@
+-v MODE:esco
+
+-v NUMBER_OF_ITEMS:1
+-v NUMBER_OF_LOTS:1
+
+-v TENDER_MEAT:True
+-v ITEM_MEAT:True
+-v LOT_MEAT:True
+
+-v FUNDING_KIND:budget
+
+
+-i create_tender
+-i find_tender
+-i tender_view
+-i meat_view
+-i lot_view
+
+-i extend_tendering_period
+-i add_tender_doc
+-i add_lot_doc
+-i modify_lot_value_amount
+#-i add_lot
+  #-i delete_lot
+-i add_item
+  -i delete_item
+-i add_tender_meat
+  -i delete_tender_meat
+-i add_lot_meat
+  -i delete_lot_meat
+-i add_item_meat
+  -i delete_item_meat
+
+-i ask_question_to_tender
+  -i answer_question_to_tender
+-i ask_question_to_item
+  -i answer_question_to_item
+-i ask_question_to_lot
+  -i answer_question_to_lot
+-i modify_tender_after_questions
+-i modify_lot_after_questions
+
+-i create_tender_claim
+  -i answer_tender_claim
+  -i resolve_tender_claim
+-i modify_tender_after_claim
+
+-i create_lot_claim
+  -i answer_lot_claim
+  -i resolve_lot_claim
+-i modify_lot_after_claim
+
+-i make_bid_without_related_lot
+-i make_bid_without_parameters
+-i make_bid_by_provider
+  -i modify_bid_by_provider
+  -i add_doc_to_bid_by_provider
+-i make_bid_by_provider1
+-i bid_view_in_tendering_period
+
+-i add_bid_doc_after_tendering_period_by_provider
+-i modify_bid_doc_after_tendering_period_by_provider
+-i modify_bid_after_tendering_period_by_provider1
+-i cancel_bid_after_tendering_period_by_provider1
+
+-i ask_question_to_tender_after_tendering_period
+-i ask_question_to_item_after_tendering_period
+-i ask_question_to_lot_after_tendering_period
+
+-i open_tender_view
+-i open_modify_tender_in_tendering_period
+  -i open_confirm_first_bid
+  -i open_confirm_second_bid
+
+-i esco_make_bid_doc_private_by_provider
+-i esco_add_financial_bid_doc_by_provider
+-i esco_add_qualification_bid_doc_by_provider
+-i esco_add_eligibility_bid_doc_by_provider
+
+-i pre-qualification_add_doc_to_tender
+-i pre-qualification_add_doc_to_lot
+
+-i pre-qualification_view
+
+#-i pre-qualifications_check_by_edrpou
+
+-i pre-qualification_add_doc_to_first_bid
+-i pre-qualification_approve_first_bid
+
+-i pre-qualification_add_doc_to_second_bid
+-i pre-qualification_reject_second_bid
+  -i pre-qualification_cancel_second_bid_qualification
+-i pre-qualification_approve_second_bid
+
+-i pre-qualification_approve_qualifications
+
+-i auction_url
+
+-i auction
+
+-i qualification_add_doc_to_first_award
+
+#-i qualifications_check_by_edrpou
+
+-i qualification_approve_first_award
+-i qualification_cancel_first_award
+-i qualification_reject_second_award
+-i qualification_add_doc_to_third_award
+-i qualification_approve_third_award
+
+-i tender_view
+-i contract_view
+-i modify_contract
+-i add_doc_to_contract
+-i contract_sign
+
+-i find_contract
+-i access_contract
+-i submit_change
+-i view_change
+-i upload_change_document
+-i modify_change
+-i apply_change
+-i add_contract_doc
+-i termination_reasons
+-i amount_paid
+-i contract_termination

--- a/robot_tests_arguments/esco_multilot_other.txt
+++ b/robot_tests_arguments/esco_multilot_other.txt
@@ -1,0 +1,123 @@
+-v MODE:esco
+
+-v NUMBER_OF_ITEMS:1
+-v NUMBER_OF_LOTS:3
+
+-v TENDER_MEAT:False
+-v ITEM_MEAT:False
+-v LOT_MEAT:False
+
+-v FUNDING_KIND:other
+
+
+-i create_tender
+-i find_tender
+-i tender_view
+
+
+-i extend_tendering_period
+-i add_tender_doc
+-i add_lot_doc
+-i modify_lot_value_amount
+#-i add_lot
+  #-i delete_lot
+-i add_item
+  -i delete_item
+
+-i ask_question_to_tender
+  -i answer_question_to_tender
+-i ask_question_to_item
+  -i answer_question_to_item
+-i ask_question_to_lot
+  -i answer_question_to_lot
+-i modify_tender_after_questions
+-i modify_lot_after_questions
+
+-i create_tender_claim
+  -i answer_tender_claim
+  -i resolve_tender_claim
+-i modify_tender_after_claim
+
+-i create_lot_claim
+  -i answer_lot_claim
+  -i resolve_lot_claim
+-i modify_lot_after_claim
+
+-i make_bid_without_related_lot
+-i make_bid_without_parameters
+-i make_bid_by_provider
+  -i modify_bid_by_provider
+  -i add_doc_to_bid_by_provider
+-i make_bid_by_provider1
+-i bid_view_in_tendering_period
+
+-i add_bid_doc_after_tendering_period_by_provider
+-i modify_bid_doc_after_tendering_period_by_provider
+-i modify_bid_after_tendering_period_by_provider1
+-i cancel_bid_after_tendering_period_by_provider1
+
+-i ask_question_to_tender_after_tendering_period
+-i ask_question_to_item_after_tendering_period
+-i ask_question_to_lot_after_tendering_period
+
+-i open_tender_view
+-i open_modify_tender_in_tendering_period
+  -i open_confirm_first_bid
+  -i open_confirm_second_bid
+
+-i esco_make_bid_doc_private_by_provider
+-i esco_add_financial_bid_doc_by_provider
+-i esco_add_qualification_bid_doc_by_provider
+-i esco_add_eligibility_bid_doc_by_provider
+
+-i pre-qualification_add_doc_to_tender
+-i pre-qualification_add_doc_to_lot
+
+-i pre-qualification_view
+
+#-i pre-qualifications_check_by_edrpou
+
+-i pre-qualification_add_doc_to_first_bid
+-i pre-qualification_approve_first_bid
+
+-i pre-qualification_add_doc_to_second_bid
+-i pre-qualification_reject_second_bid
+  -i pre-qualification_cancel_second_bid_qualification
+-i pre-qualification_approve_second_bid
+
+-i pre-qualification_approve_other_bids
+
+-i pre-qualification_approve_qualifications
+
+-i auction_url
+
+-i auction
+
+-i qualification_add_doc_to_first_award
+
+#-i qualifications_check_by_edrpou
+
+-i qualification_add_doc_to_first_award
+-i qualification_approve_first_award
+-i qualification_add_doc_to_second_award
+-i qualification_approve_second_award
+-i qualification_cancel_second_award
+-i qualification_reject_other_awards
+
+-i tender_view
+-i contract_view
+-i modify_contract
+-i add_doc_to_contract
+-i contract_sign
+
+-i find_contract
+-i access_contract
+-i submit_change
+-i view_change
+-i upload_change_document
+-i modify_change
+-i apply_change
+-i add_contract_doc
+-i termination_reasons
+-i amount_paid
+-i contract_termination

--- a/robot_tests_arguments/esco_no_lots_other.txt
+++ b/robot_tests_arguments/esco_no_lots_other.txt
@@ -1,0 +1,86 @@
+-v MODE:esco
+
+-v NUMBER_OF_ITEMS:1
+-v NUMBER_OF_LOTS:0
+
+-v TENDER_MEAT:False
+-v ITEM_MEAT:False
+-v LOT_MEAT:False
+
+
+-v FUNDING_KIND:other
+
+-i create_tender
+-i find_tender
+-i tender_view
+
+-i extend_tendering_period
+-i add_tender_doc
+-i add_lot_doc
+-i modify_lot_value_amount
+#-i add_lot
+  #-i delete_lot
+-i add_item
+  -i delete_item
+
+-i ask_question_to_tender
+  -i answer_question_to_tender
+-i ask_question_to_item
+  -i answer_question_to_item
+-i ask_question_to_lot
+  -i answer_question_to_lot
+-i modify_tender_after_questions
+
+-i create_tender_claim
+  -i answer_tender_claim
+  -i resolve_tender_claim
+-i modify_tender_after_claim
+
+-i make_bid_without_related_lot
+-i make_bid_without_parameters
+-i make_bid_by_provider
+  -i modify_bid_by_provider
+  -i add_doc_to_bid_by_provider
+-i make_bid_by_provider1
+-i bid_view_in_tendering_period
+
+-i add_bid_doc_after_tendering_period_by_provider
+-i modify_bid_doc_after_tendering_period_by_provider
+-i modify_bid_after_tendering_period_by_provider1
+-i cancel_bid_after_tendering_period_by_provider1
+
+-i ask_question_to_tender_after_tendering_period
+-i ask_question_to_item_after_tendering_period
+-i ask_question_to_lot_after_tendering_period
+
+-i open_tender_view
+-i open_modify_tender_in_tendering_period
+  -i open_confirm_first_bid
+  -i open_confirm_second_bid
+
+-i pre-qualification_add_doc_to_tender
+-i pre-qualification_add_doc_to_lot
+
+-i pre-qualification_view
+
+-i pre-qualification_add_doc_to_first_bid
+-i pre-qualification_approve_first_bid
+
+-i pre-qualification_add_doc_to_second_bid
+-i pre-qualification_reject_second_bid
+  -i pre-qualification_cancel_second_bid_qualification
+-i pre-qualification_approve_second_bid
+
+-i pre-qualification_approve_qualifications
+
+-i auction_url
+
+-i auction
+
+#-i qualifications_check_by_edrpou
+-i qualification_approve_first_award
+
+-i contract_view
+-i modify_contract
+-i add_doc_to_contract
+-i contract_sign


### PR DESCRIPTION
Currently auctions are skipped in the esco scenarios, thus the no-auction mode should be set with a command line argument: -v submissionMethodDetails:"quick(mode:no-auction)". Otherwise the default value submissionMethodDetails:"quick" will be set.
Since there are no auctions, it is necessary to exclude the auction_url tag with a command line argument: -e auction_url.
Thus, the openProcedure test suite will be run with the command:
bin/op_tests -s openProcedure -A robot_tests_arguments/(name of the argument file) -e auction_url -v submissionMethodDetails:"quick(mode:no-auction)"
For details on esco scenarios description see: https://docs.google.com/a/quintagroup.com/document/d/1ML_-lD_McXMJd9bQYCZS8E4z03LEaS6Nxhh6PEdMzww/edit?usp=sharing
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/621)
<!-- Reviewable:end -->
