### PR TITLE
New variable for submissionMethodDetails

### DIFF
--- a/op_robot_tests/tests_files/initial_data.py
+++ b/op_robot_tests/tests_files/initial_data.py
@@ -137,13 +137,17 @@ def create_fake_url():
     return '{0}/{1}x{2}/{3}/{4}.png'.format(base, size_x, size_y, background_color, font_color)
 
 
-def test_tender_data(params, periods=("enquiry", "tender")):
+def test_tender_data(params,
+                    periods=("enquiry", "tender"),
+                    submissionMethodDetails=None):
+    submissionMethodDetails = submissionMethodDetails \
+        if submissionMethodDetails else "quick"
     now = get_now()
     value_amount = create_fake_amount()  # max value equals to budget of Ukraine in hryvnias
 
     data = {
         "mode": "test",
-        "submissionMethodDetails": "quick",
+        "submissionMethodDetails": submissionMethodDetails,
         "description": fake.description(),
         "description_en": fake_en.sentence(nb_words=10, variable_nb_words=True),
         "description_ru": fake_ru.sentence(nb_words=10, variable_nb_words=True),
@@ -297,8 +301,8 @@ def test_item_data_financial(cav):
     return munchify(data)
 
 
-def test_tender_data_dgf_other(params):
-    data = test_tender_data(params, [])
+def test_tender_data_dgf_other(params, submissionMethodDetails):
+    data = test_tender_data(params, [], submissionMethodDetails)
 
     data['dgfID'] = fake.dgfID()
     data['dgfDecisionID'] = fake.dgfDecisionID()
@@ -334,8 +338,8 @@ def test_tender_data_dgf_other(params):
     return data
 
 
-def test_tender_data_dgf_financial(params):
-    data = test_tender_data(params, [])
+def test_tender_data_dgf_financial(params, submissionMethodDetails):
+    data = test_tender_data(params, [], submissionMethodDetails)
 
     data['dgfID'] = fake.dgfID()
     data['dgfDecisionID'] = fake.dgfDecisionID()
@@ -371,8 +375,8 @@ def test_tender_data_dgf_financial(params):
     return data
 
 
-def test_tender_data_dgf_insider(params):
-    data = test_tender_data(params, [])
+def test_tender_data_dgf_insider(params, submissionMethodDetails):
+    data = test_tender_data(params, [], submissionMethodDetails)
 
     data['dgfID'] = fake.dgfID()
     data['dgfDecisionID'] = fake.dgfDecisionID()

--- a/op_robot_tests/tests_files/keywords.robot
+++ b/op_robot_tests/tests_files/keywords.robot
@@ -199,7 +199,8 @@ Get Broker Property By Username
 Підготувати дані для створення тендера
   [Arguments]  ${tender_parameters}
   ${period_intervals}=  compute_intrs  ${BROKERS}  ${used_brokers}
-  ${tender_data}=  prepare_test_tender_data  ${period_intervals}  ${tender_parameters}
+  ${submissionMethodDetails}=  Get Variable Value  ${submissionMethodDetails}
+  ${tender_data}=  prepare_test_tender_data  ${period_intervals}  ${tender_parameters}  ${submissionMethodDetails}
   ${TENDER}=  Create Dictionary
   Set Global Variable  ${TENDER}
   Log  ${tender_data}

--- a/op_robot_tests/tests_files/service_keywords.py
+++ b/op_robot_tests/tests_files/service_keywords.py
@@ -305,7 +305,9 @@ def compute_intrs(brokers_data, used_brokers):
     return result
 
 
-def prepare_test_tender_data(procedure_intervals, tender_parameters):
+def prepare_test_tender_data(procedure_intervals,
+                            tender_parameters,
+                            submissionMethodDetails):
     # Get actual intervals by mode name
     mode = tender_parameters['mode']
     if mode in procedure_intervals:
@@ -322,13 +324,13 @@ def prepare_test_tender_data(procedure_intervals, tender_parameters):
     assert intervals['accelerator'] >= 0, \
         "Accelerator should not be less than 0"
     if mode == 'belowThreshold':
-        return munchify({'data': test_tender_data(tender_parameters)})
+        return munchify({'data': test_tender_data(tender_parameters, submissionMethodDetails=submissionMethodDetails)})
     elif mode == 'dgfFinancialAssets':
-        return munchify({'data': test_tender_data_dgf_financial(tender_parameters)})
+        return munchify({'data': test_tender_data_dgf_financial(tender_parameters, submissionMethodDetails)})
     elif mode == 'dgfOtherAssets':
-        return munchify({'data': test_tender_data_dgf_other(tender_parameters)})
+        return munchify({'data': test_tender_data_dgf_other(tender_parameters, submissionMethodDetails)})
     elif mode == 'dgfInsider':
-        return munchify({'data': test_tender_data_dgf_insider(tender_parameters)})
+        return munchify({'data': test_tender_data_dgf_insider(tender_parameters, submissionMethodDetails)})
     raise ValueError("Invalid mode for prepare_test_tender_data")
 
 


### PR DESCRIPTION
This variable can be specified as a command line argument, e.g. -v submissionMethodDetails:"quick". Currently supported values are listed here. If the variable is not set, the submissionMethodDetails field of the initial tender data falls back to its default value – quick.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/robot_tests/737)
<!-- Reviewable:end -->
